### PR TITLE
Allow access to pair inside Watcher

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -4,7 +4,7 @@ use bytemuck::{bytes_of, Pod};
 
 #[derive(Copy, Clone, Default)]
 pub struct Watcher<T> {
-    pair: Option<Pair<T>>,
+    pub pair: Option<Pair<T>>,
 }
 
 impl<T> Watcher<T> {


### PR DESCRIPTION
This change permits free access the pair inside a Watcher, allowing to see its contents even outside the scope calling update().

This is a pretty much required change if an autosplitter uses different functions for different actions (start, split, reset, etc), and it's pretty harmless otherwise.