### PR TITLE
Manually impl Default for Watcher

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -2,9 +2,16 @@ use core::{mem, ops};
 
 use bytemuck::{bytes_of, Pod};
 
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone)]
 pub struct Watcher<T> {
     pub pair: Option<Pair<T>>,
+}
+
+// We need to impl Default manually here because the derive implmentation adds the unnecessary `T: Default` bound
+impl<T> Default for Watcher<T> {
+    fn default() -> Self {
+        Self { pair: None }
+    }
 }
 
 impl<T> Watcher<T> {


### PR DESCRIPTION
The default `Default` implementation provided by rust always adds the bound that `T: Default` when deriving `Default` for a generic struct. The generated code in this case looks like this.
```rs
    #[automatically_derived]
    impl<T: ::core::default::Default> ::core::default::Default for Watcher<T> {
        #[inline]
        fn default() -> Watcher<T> {
            Watcher {
                pair: ::core::default::Default::default(),
            }
        }
    }
```

This prevents us from calling `Watcher::Default()` when `T` is not default, even though we only hold an `Option` internally that always implements `Default` (returns `None`).

By implementing `Default` ourselves we can use `Watcher::<T>::Default()` for any `T`. 

Example
```rs
// This does not impl Default
enum Foo {
    Bar,
    Baz,
}

let watcher: Watcher<Foo> = Watcher::Default; // Still works!
```
