### PR TITLE
Update `syn` to 2.0

### DIFF
--- a/asr-derive/Cargo.toml
+++ b/asr-derive/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = "1.0.95"
+syn = "2.0.1"
 quote = "1.0.18"
 heck = "0.4.0"
 


### PR DESCRIPTION
With `bytemuck` now using `syn` 2.0, we should do the same so compile times stay low.