### PR TITLE
Relax the `bytemuck` bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 arrayvec = { version = "0.7.2", default-features = false, optional = true }
 asr-derive = { path = "asr-derive", optional = true }
 bitflags = { version = "2.2.1", optional = true }
-bytemuck = { version = "1.9.1", features = ["derive", "min_const_generics"] }
+bytemuck = { version = "1.13.1", features = ["derive", "min_const_generics"] }
 itoa = { version = "1.0.1", default-features = false, optional = true }
 memchr = { version = "2.5.0", default-features = false, optional = true }
 ryu = { version = "1.0.11", default-features = false, optional = true }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -242,7 +242,7 @@ fn matches<const N: usize>(scan: &[u8; N], needle: &[u8; N], mask: &[u8; N]) -> 
             needle = needle.add(2);
             i += 2;
         }
-        while i + 1 <= N {
+        while i < N {
             if *scan & *mask != *needle {
                 return false;
             }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -7,7 +7,8 @@ pub struct Watcher<T> {
     pub pair: Option<Pair<T>>,
 }
 
-// We need to impl Default manually here because the derive implmentation adds the unnecessary `T: Default` bound
+// We need to impl Default manually here because the derive implementation adds
+// the unnecessary `T: Default` bound
 impl<T> Default for Watcher<T> {
     #[inline]
     fn default() -> Self {
@@ -41,7 +42,7 @@ impl<T: Copy> Watcher<T> {
     }
 
     pub fn update_infallible(&mut self, value: T) -> &Pair<T> {
-        let pair = self.pair.get_or_insert_with(|| Pair {
+        let pair = self.pair.get_or_insert(Pair {
             old: value,
             current: value,
         });


### PR DESCRIPTION
It's actually fine if the structs we read have padding, there's no reason why that would cause any Undefined Behavior. So we can use `AnyBitPattern` instead as the bound. However, I also noticed that `bytemuck` has `CheckedBitPattern` which builds on top of `AnyBitPattern` but allows for types where not every bit pattern is valid. For those `bytemuck` then defines a function that allows you to check the validity. `CheckedBitPattern` is implemented for `AnyBitPattern` (by doing nothing), so we can just always use `CheckedBitPattern` and support even more complex types.