### PR TITLE
Add a macro for defining a panic handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrayvec = { version = "0.7.2", default-features = false, optional = true }
+arrayvec = { version = "0.7.2", default-features = false }
 asr-derive = { path = "asr-derive", optional = true }
 bitflags = { version = "2.2.1", optional = true }
 bytemuck = { version = "1.13.1", features = ["derive", "min_const_generics"] }
@@ -20,7 +20,6 @@ integer-vars = ["itoa"]
 float-vars = ["ryu"]
 float-vars-small = ["float-vars", "ryu/small"]
 flags = ["bitflags"]
-strings = ["arrayvec"]
 gba = []
 signature = ["memchr"]
 derive = ["asr-derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod watcher;
 pub mod gba;
 
 pub use self::runtime::*;
+pub use arrayvec;
 pub use time;
 
 #[cfg(feature = "derive")]
@@ -55,5 +56,5 @@ pub use itoa;
 #[cfg(feature = "ryu")]
 pub use ryu;
 
-#[cfg(feature = "arrayvec")]
-pub use arrayvec;
+#[macro_use]
+mod panic;

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,0 +1,94 @@
+/// Defines a panic handler for the auto splitter that aborts execution. By
+/// default it will only print the panic message in debug builds. A stack based
+/// buffer of 1024 bytes is used by default. If the message is too long, it will
+/// be truncated. All of this can be configured.
+///
+/// # Usage
+///
+/// ```no_run
+/// asr::panic_handler! {
+///     /// When to print the panic message.
+///     /// Default: debug
+///     print: never | debug | always,
+///
+///     /// The size of the stack based buffer in bytes.
+///     /// Default: 1024
+///     buffer: <number>,
+/// }
+/// ```
+///
+/// # Example
+///
+/// The default configuration will print a message in debug builds:
+/// ```no_run
+/// asr::panic_handler!();
+/// ```
+///
+/// A message will always be printed with a buffer size of 512 bytes:
+/// ```no_run
+/// asr::panic_handler! {
+///     print: always,
+///     buffer: 512,
+/// }
+/// ```
+///
+/// A message will always be printed with the default buffer size:
+/// ```no_run
+/// asr::panic_handler! {
+///     print: always,
+/// }
+/// ```
+///
+/// A message will never be printed:
+/// ```no_run
+/// asr::panic_handler! {
+///     print: never,
+/// }
+/// ```
+///
+/// A message will be printed in debug builds, with a buffer size of 512 bytes:
+/// ```no_run
+/// asr::panic_handler! {
+///     buffer: 512,
+/// }
+/// ```
+#[macro_export]
+macro_rules! panic_handler {
+    () => { $crate::panic_handler!(print: debug); };
+    (print: never $(,)?) => {
+        #[cfg(all(not(test), target_family = "wasm"))]
+        #[panic_handler]
+        fn panic(_: &core::panic::PanicInfo) -> ! {
+            #[cfg(target_arch = "wasm32")]
+            core::arch::wasm32::unreachable();
+            #[cfg(target_arch = "wasm64")]
+            core::arch::wasm64::unreachable();
+        }
+    };
+    (buffer: $N:expr $(,)?) => { $crate::panic_handler!(print: debug, buffer: $N); };
+    (print: always $(,)?) => { $crate::panic_handler!(print: always, buffer: 1024); };
+    (print: always, buffer: $N:expr $(,)?) => {
+        #[cfg(all(not(test), target_family = "wasm"))]
+        #[panic_handler]
+        fn panic(info: &core::panic::PanicInfo) -> ! {
+            asr::print_limited::<$N>(info);
+            #[cfg(target_arch = "wasm32")]
+            core::arch::wasm32::unreachable();
+            #[cfg(target_arch = "wasm64")]
+            core::arch::wasm64::unreachable();
+        }
+    };
+    (print: debug $(,)?) => { $crate::panic_handler!(print: debug, buffer: 1024); };
+    (print: debug, buffer: $N:expr $(,)?) => {
+        #[cfg(all(not(test), target_family = "wasm"))]
+        #[panic_handler]
+        fn panic(_info: &core::panic::PanicInfo) -> ! {
+            #[cfg(debug_assertions)]
+            asr::print_limited::<$N>(_info);
+            #[cfg(target_arch = "wasm32")]
+            core::arch::wasm32::unreachable();
+            #[cfg(target_arch = "wasm64")]
+            core::arch::wasm64::unreachable();
+        }
+    };
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -55,7 +55,6 @@ pub fn print_message(text: &str) {
 /// asr::print_limited::<128>(&format_args!("Hello, {}!", "world"));
 /// ```
 #[inline(never)]
-#[cfg(feature = "arrayvec")]
 pub fn print_limited<const CAP: usize>(message: &dyn core::fmt::Display) {
     let mut buf = arrayvec::ArrayString::<CAP>::new();
     let _ = core::fmt::Write::write_fmt(&mut buf, format_args!("{message}"));
@@ -68,7 +67,6 @@ pub fn print_limited<const CAP: usize>(message: &dyn core::fmt::Display) {
 ///
 /// Example values: `windows`, `linux`, `macos`
 #[inline]
-#[cfg(feature = "arrayvec")]
 pub fn get_os() -> Result<arrayvec::ArrayString<16>, Error> {
     let mut buf = arrayvec::ArrayString::<16>::new();
     // SAFETY: We provide a valid pointer and length to the buffer. We check
@@ -93,7 +91,6 @@ pub fn get_os() -> Result<arrayvec::ArrayString<16>, Error> {
 ///
 /// Example values: `x86`, `x86_64`, `arm`, `aarch64`
 #[inline]
-#[cfg(feature = "arrayvec")]
 pub fn get_arch() -> Result<arrayvec::ArrayString<16>, Error> {
     let mut buf = arrayvec::ArrayString::<16>::new();
     // SAFETY: We provide a valid pointer and length to the buffer. We check

--- a/src/runtime/sys.rs
+++ b/src/runtime/sys.rs
@@ -108,7 +108,6 @@ extern "C" {
     /// `buf_len_ptr` will be set to the required buffer size. The name is
     /// guaranteed to be valid UTF-8 and is not nul-terminated.
     /// Example values: `windows`, `linux`, `macos`
-    #[cfg(feature = "arrayvec")]
     pub fn runtime_get_os(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
     /// Stores the name of the architecture that the runtime is running on
     /// in the buffer given. Returns `false` if the buffer is too small.
@@ -116,7 +115,6 @@ extern "C" {
     /// `buf_len_ptr` will be set to the required buffer size. The name is
     /// guaranteed to be valid UTF-8 and is not nul-terminated.
     /// Example values: `x86`, `x86_64`, `arm`, `aarch64`
-    #[cfg(feature = "arrayvec")]
     pub fn runtime_get_arch(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 
     /// Adds a new setting that the user can modify. This will return either


### PR DESCRIPTION
This adds a macro `asr::panic_handler!()` which allows the user to easily define a panic handler for their auto splitter. By default it prints a message of up to 1024 bytes in debug builds and doesn't print anything in release builds. This is all highly configurable.

```rust
asr::panic_handler! {
    /// When to print the panic message.
    /// Default: debug
    print: never | debug | always,

    /// The size of the stack based buffer in bytes.
    /// Default: 1024
    buffer: <number>,
}
```