### PR TITLE
Take `Into<Address>` as argument

### DIFF
--- a/src/emulator/gba.rs
+++ b/src/emulator/gba.rs
@@ -25,8 +25,12 @@ impl Emulator {
     }
 
     /// Reads a value from the emulator's memory.
-    pub fn read<T: CheckedBitPattern>(&self, addr: Address) -> Result<T, runtime::Error> {
-        let address = addr.value();
+    pub fn read<T: CheckedBitPattern>(
+        &self,
+        addr: impl Into<Address>,
+    ) -> Result<T, runtime::Error> {
+        let address: Address = addr.into();
+        let address = address.value();
         let memory_section = address >> 24;
         let ram_addr = match memory_section {
             2 => self.ewram,
@@ -62,8 +66,7 @@ fn look_for_mgba() -> Option<Emulator> {
 fn look_for_vba() -> Option<Emulator> {
     let process = Process::attach("VisualBoyAdvance.exe")?;
 
-    let [ewram, iwram]: [Address32; 2] =
-        process.read(Address::new(0x00400000 + 0x001A8F50)).ok()?;
+    let [ewram, iwram]: [Address32; 2] = process.read(0x00400000u32 + 0x001A8F50u32).ok()?;
 
     if ewram.is_null() || iwram.is_null() {
         return None;

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -1,0 +1,4 @@
+//! Support for attaching to various emulators.
+
+#[cfg(feature = "gba")]
+pub mod gba;

--- a/src/future.rs
+++ b/src/future.rs
@@ -188,12 +188,7 @@ impl Process {
     /// Asynchronously awaits the address and size of a module in the process,
     /// yielding back to the runtime between each try.
     pub async fn wait_module_range(&self, name: &str) -> (Address, u64) {
-        retry(|| {
-            let address = self.get_module_address(name).ok()?;
-            let size = self.get_module_size(name).ok()?;
-            Some((address, size))
-        })
-        .await
+        retry(|| self.get_module_range(name).ok()).await
     }
 }
 
@@ -206,10 +201,10 @@ impl<const N: usize> Signature<N> {
     pub async fn wait_scan_process_range(
         &self,
         process: &Process,
-        addr: Address,
-        len: u64,
+        (addr, len): (impl Into<Address>, u64),
     ) -> Address {
-        retry(|| self.scan_process_range(process, addr, len)).await
+        let addr = addr.into();
+        retry(|| self.scan_process_range(process, (addr, len))).await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,7 @@
 mod primitives;
 mod runtime;
 
-pub use primitives::*;
-
+pub mod emulator;
 #[macro_use]
 pub mod future;
 #[cfg(feature = "signature")]
@@ -137,10 +136,7 @@ pub mod sync;
 pub mod time_util;
 pub mod watcher;
 
-#[cfg(feature = "gba")]
-pub mod gba;
-
-pub use self::runtime::*;
+pub use self::{primitives::*, runtime::*};
 pub use arrayvec;
 pub use time;
 

--- a/src/runtime/memory_range.rs
+++ b/src/runtime/memory_range.rs
@@ -56,6 +56,12 @@ impl MemoryRange<'_> {
         }
     }
 
+    /// Queries the address and size of the memory range.
+    #[inline]
+    pub fn range(&self) -> Result<(Address, u64), Error> {
+        Ok((self.address()?, self.size()?))
+    }
+
     /// Queries the flags of the memory range.
     #[cfg(feature = "flags")]
     #[inline]

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -192,9 +192,9 @@ impl<const N: usize> Signature<N> {
     pub fn scan_process_range(
         &self,
         process: &Process,
-        mut addr: Address,
-        len: u64,
+        (addr, len): (impl Into<Address>, u64),
     ) -> Option<Address> {
+        let mut addr: Address = Into::into(addr);
         // TODO: Handle the case where a signature may be cut in half by a page
         // boundary.
         let overall_end = addr.value() + len;

--- a/src/string.rs
+++ b/src/string.rs
@@ -4,6 +4,8 @@ use core::{ops, str};
 
 use bytemuck::{Pod, Zeroable};
 
+pub use arrayvec::ArrayString;
+
 /// A nul-terminated string that is stored in an array of a fixed size `N`. This
 /// can be read from a process's memory.
 #[derive(Copy, Clone)]

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -2,7 +2,7 @@
 
 use core::{mem, ops};
 
-use bytemuck::{bytes_of, Pod};
+use bytemuck::{bytes_of, NoUninit};
 
 /// A watcher keeps a pair of values and allows you to track changes between
 /// them.
@@ -122,7 +122,7 @@ impl<T: Eq> Pair<T> {
     }
 }
 
-impl<T: Pod> Pair<T> {
+impl<T: NoUninit> Pair<T> {
     /// Checks if the bytes of the value changed.
     pub fn bytes_changed(&self) -> bool {
         bytes_of(&self.old) != bytes_of(&self.current)


### PR DESCRIPTION
This changes it so that all functions taking an address now allow you to pass anything that can be converted into an address. Additionally this contains a few other smaller changes such as preparing to support multiple emulators and convenience functions that return and take a (address, size) pair.