### PR TITLE
Allow accessing the path of a process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,15 @@ ryu = { version = "1.0.11", default-features = false, optional = true }
 time = { version = "0.3.5", default-features = false }
 
 [features]
-integer-vars = ["itoa"]
+alloc = []
+derive = ["asr-derive"]
+flags = ["bitflags"]
 float-vars = ["ryu"]
 float-vars-small = ["float-vars", "ryu/small"]
-flags = ["bitflags"]
+integer-vars = ["itoa"]
+signature = ["memchr"]
+
+# Emulators
 gba = []
 genesis = ["flags", "signature"]
 ps1 = ["flags", "signature"]
-signature = ["memchr"]
-derive = ["asr-derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,9 @@
 //! }
 //! ```
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 mod primitives;
 mod runtime;
 

--- a/src/runtime/sys.rs
+++ b/src/runtime/sys.rs
@@ -83,6 +83,9 @@ extern "C" {
         name_len: usize,
     ) -> Option<NonZeroU64>;
 
+    #[cfg(feature = "alloc")]
+    pub fn process_get_path(process: ProcessId, buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
+
     /// Gets the number of memory ranges in a given process.
     pub fn process_get_memory_range_count(process: ProcessId) -> Option<NonZeroU64>;
     /// Gets the start address of a memory range by its index.


### PR DESCRIPTION
With the newly added WASI support, you may want to read the actual executable of a process or files surrounding the executable. It is therefore important that you can get the path of the process to locate its executable in the file system. This adds the functionality to do so. However, because paths are potentially unbounded in size we gate this functionality behind a new `alloc` feature.