### PR TITLE
Add functions for skipping and undoing splits

### DIFF
--- a/src/runtime/sys.rs
+++ b/src/runtime/sys.rs
@@ -34,6 +34,10 @@ extern "C" {
     pub fn timer_start();
     /// Splits the current segment.
     pub fn timer_split();
+    /// Skips the current split.
+    pub fn timer_skip_split();
+    /// Undoes the previous split.
+    pub fn timer_undo_split();
     /// Resets the timer.
     pub fn timer_reset();
     /// Sets a custom key value pair. This may be arbitrary information that

--- a/src/runtime/timer.rs
+++ b/src/runtime/timer.rs
@@ -33,6 +33,20 @@ pub fn split() {
     unsafe { sys::timer_split() }
 }
 
+/// Skips the current split.
+#[inline]
+pub fn skip_split() {
+    // SAFETY: It is always safe to call this function.
+    unsafe { sys::timer_skip_split() }
+}
+
+/// Undoes the previous split.
+#[inline]
+pub fn undo_split() {
+    // SAFETY: It is always safe to call this function.
+    unsafe { sys::timer_undo_split() }
+}
+
 /// Resets the timer.
 #[inline]
 pub fn reset() {


### PR DESCRIPTION
These were just added to the runtime. These are mostly discouraged for most cases, but there are cases where it may make sense to use them.