### PR TITLE
Extend the Unity class derive macro

### DIFF
--- a/asr-derive/src/lib.rs
+++ b/asr-derive/src/lib.rs
@@ -210,15 +210,19 @@ mod unity;
 /// A derive macro that can be used to bind to a .NET class. This allows reading
 /// the contents of an instance of the class described by the struct from a
 /// process. Each field must match the name of the field in the class exactly
-/// and needs to be of a type that can be read from a process.
+/// (or alternatively renamed with the `#[rename = "..."]` attribute) and needs
+/// to be of a type that can be read from a process. Fields can be marked as
+/// static with the `#[static_field]` attribute.
 ///
 /// # Example
 ///
 /// ```no_run
 /// #[derive(Class)]
 /// struct Timer {
-///     currentLevelTime: f32,
-///     timerStopped: bool,
+///     #[rename = "currentLevelTime"]
+///     level_time: f32,
+///     #[static_field]
+///     foo: bool,
 /// }
 /// ```
 ///
@@ -228,7 +232,7 @@ mod unity;
 /// class Timer
 /// {
 ///     float currentLevelTime;
-///     bool timerStopped;
+///     static bool foo;
 ///     // ...
 /// }
 /// ```
@@ -247,8 +251,11 @@ mod unity;
 ///     // Do something with the instance.
 /// }
 /// ```
+///
+/// If only static fields are present, the `read` method does not take an
+/// instance argument.
 #[cfg(feature = "unity")]
-#[proc_macro_derive(Il2cppClass)]
+#[proc_macro_derive(Il2cppClass, attributes(static_field, rename))]
 pub fn il2cpp_class_binding(input: TokenStream) -> TokenStream {
     unity::process(input, quote! { asr::game_engine::unity::il2cpp })
 }
@@ -256,15 +263,19 @@ pub fn il2cpp_class_binding(input: TokenStream) -> TokenStream {
 /// A derive macro that can be used to bind to a .NET class. This allows reading
 /// the contents of an instance of the class described by the struct from a
 /// process. Each field must match the name of the field in the class exactly
-/// and needs to be of a type that can be read from a process.
+/// (or alternatively renamed with the `#[rename = "..."]` attribute) and needs
+/// to be of a type that can be read from a process. Fields can be marked as
+/// static with the `#[static_field]` attribute.
 ///
 /// # Example
 ///
 /// ```no_run
 /// #[derive(Class)]
 /// struct Timer {
-///     currentLevelTime: f32,
-///     timerStopped: bool,
+///     #[rename = "currentLevelTime"]
+///     level_time: f32,
+///     #[static_field]
+///     foo: bool,
 /// }
 /// ```
 ///
@@ -274,7 +285,7 @@ pub fn il2cpp_class_binding(input: TokenStream) -> TokenStream {
 /// class Timer
 /// {
 ///     float currentLevelTime;
-///     bool timerStopped;
+///     static bool foo;
 ///     // ...
 /// }
 /// ```
@@ -293,8 +304,11 @@ pub fn il2cpp_class_binding(input: TokenStream) -> TokenStream {
 ///     // Do something with the instance.
 /// }
 /// ```
+///
+/// If only static fields are present, the `read` method does not take an
+/// instance argument.
 #[cfg(feature = "unity")]
-#[proc_macro_derive(MonoClass)]
+#[proc_macro_derive(MonoClass, attributes(static_field, rename))]
 pub fn mono_class_binding(input: TokenStream) -> TokenStream {
     unity::process(input, quote! { asr::game_engine::unity::mono })
 }

--- a/asr-derive/src/unity.rs
+++ b/asr-derive/src/unity.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::{quote, quote_spanned, ToTokens};
-use syn::{Data, DeriveInput, Ident};
+use syn::{Data, DeriveInput, Expr, ExprLit, Ident, Lit, Meta};
 
 pub fn process(input: TokenStream, mono_module: impl ToTokens) -> TokenStream {
     let ast: DeriveInput = syn::parse(input).unwrap();
@@ -15,24 +15,76 @@ pub fn process(input: TokenStream, mono_module: impl ToTokens) -> TokenStream {
 
     let binding_name = Ident::new(&format!("{struct_name}Binding"), struct_name.span());
 
+    let mut has_static = false;
+    let mut is_fully_static = true;
+
     let mut field_names = Vec::new();
-    let mut field_name_strings = Vec::new();
+    let mut lookup_names = Vec::new();
     let mut field_types = Vec::new();
     let mut field_reads = Vec::new();
     for field in struct_data.fields {
         let field_name = field.ident.clone().unwrap();
         let span = field_name.span();
-        field_reads.push(quote_spanned! { span =>
-            process.read(instance + self.#field_name).map_err(drop)?
+        let is_static = field.attrs.iter().any(|x| {
+            let Meta::Path(path) = &x.meta else { return false };
+            path.is_ident("static_field")
         });
+        field_reads.push(if is_static {
+            quote_spanned! { span =>
+                process.read(self.static_table + self.#field_name).map_err(drop)?
+            }
+        } else {
+            quote_spanned! { span =>
+                process.read(instance + self.#field_name).map_err(drop)?
+            }
+        });
+        let lookup_name = field
+            .attrs
+            .iter()
+            .find_map(|x| {
+                let Meta::NameValue(name_value) = &x.meta else { return None };
+                if !name_value.path.is_ident("rename") {
+                    return None;
+                }
+                let Expr::Lit(ExprLit {
+                lit: Lit::Str(name), ..
+            }) = &name_value.value else { return None };
+                Some(name.value())
+            })
+            .unwrap_or_else(|| field.ident.clone().unwrap().to_string());
+        has_static |= is_static;
+        is_fully_static &= is_static;
         field_names.push(field_name);
-        field_name_strings.push(field.ident.clone().unwrap().to_string());
+        lookup_names.push(lookup_name);
         field_types.push(field.ty);
     }
+
+    let static_table_field = if has_static {
+        quote! {
+            static_table: asr::Address,
+        }
+    } else {
+        quote! {}
+    };
+
+    let static_table_init = if has_static {
+        quote! {
+            static_table: class.wait_get_static_table(process, module).await,
+        }
+    } else {
+        quote! {}
+    };
+
+    let maybe_instance_param = if is_fully_static {
+        quote! {}
+    } else {
+        quote! { , instance: asr::Address }
+    };
 
     quote! {
         struct #binding_name {
             class: #mono_module::Class,
+            #static_table_field
             #(#field_names: u32,)*
         }
 
@@ -45,10 +97,11 @@ pub fn process(input: TokenStream, mono_module: impl ToTokens) -> TokenStream {
                 let class = image.wait_get_class(process, module, #stuct_name_string).await;
 
                 #(
-                    let #field_names = class.wait_get_field(process, module, #field_name_strings).await;
+                    let #field_names = class.wait_get_field(process, module, #lookup_names).await;
                 )*
 
                 #binding_name {
+                    #static_table_init
                     class,
                     #(#field_names,)*
                 }
@@ -60,7 +113,7 @@ pub fn process(input: TokenStream, mono_module: impl ToTokens) -> TokenStream {
                 &self.class
             }
 
-            fn read(&self, process: &asr::Process, instance: asr::Address) -> Result<#struct_name, ()> {
+            fn read(&self, process: &asr::Process #maybe_instance_param) -> Result<#struct_name, ()> {
                 Ok(#struct_name {#(
                     #field_names: #field_reads,
                 )*})

--- a/src/game_engine/unity/mod.rs
+++ b/src/game_engine/unity/mod.rs
@@ -34,14 +34,18 @@
 //! Alternatively you can use the `Class` derive macro to generate the bindings
 //! for you. This allows reading the contents of an instance of the class
 //! described by the struct from a process. Each field must match the name of
-//! the field in the class exactly and needs to be of a type that can be read
-//! from a process.
+//! the field in the class exactly (or alternatively renamed with the `#[rename
+//! = "..."]` attribute) and needs to be of a type that can be read from a
+//! process. Fields can be marked as static with the `#[static_field]`
+//! attribute.
 //!
 //! ```ignore
 //! #[derive(Class)]
 //! struct Timer {
-//!     currentLevelTime: f32,
-//!     timerStopped: bool,
+//!     #[rename = "currentLevelTime"]
+//!     level_time: f32,
+//!     #[static_field]
+//!     foo: bool,
 //! }
 //! ```
 //!
@@ -51,7 +55,7 @@
 //! class Timer
 //! {
 //!     float currentLevelTime;
-//!     bool timerStopped;
+//!     static bool foo;
 //!     // ...
 //! }
 //! ```
@@ -70,6 +74,9 @@
 //!     // Do something with the instance.
 //! }
 //! ```
+//!
+//! If only static fields are present, the `read` method does not take an
+//! instance argument.
 
 // References:
 // https://github.com/just-ero/asl-help/tree/4c87822df0125b027d1af75e8e348c485817592d/src/Unity


### PR DESCRIPTION
You can now rename fields to support both the C# and Rust naming conventions. Additionally you can mark fields as statics. They will be read from the static table instead of the instance.