### PR TITLE
[Unity] Added ability to look for Classes inside the linked list of Transforms

### DIFF
--- a/src/game_engine/unity/scene.rs
+++ b/src/game_engine/unity/scene.rs
@@ -2,6 +2,7 @@
 
 // References:
 // https://gist.githubusercontent.com/just-ero/92457b51baf85bd1e5b8c87de8c9835e/raw/8aa3e6b8da01fd03ff2ff0c03cbd018e522ef988/UnityScene.hpp
+// Offsets and logic for the GameObject functions taken from https://github.com/Micrologist/UnityInstanceDumper
 
 use crate::{
     file_format::pe, future::retry, signature::Signature, string::ArrayCString, Address, Address32,
@@ -15,8 +16,10 @@ use crate::{
 /// the traditional class lookup in games with no useful static references.
 pub struct SceneManager {
     is_64_bit: bool,
+    is_il2cpp: bool,
     address: Address,
     offsets: &'static Offsets,
+    pointer_size: u8,
 }
 
 impl SceneManager {
@@ -30,6 +33,7 @@ impl SceneManager {
         let unity_player = process.get_module_range("UnityPlayer.dll").ok()?;
 
         let is_64_bit = pe::MachineType::read(process, unity_player.0)? == pe::MachineType::X86_64;
+        let is_il2cpp = process.get_module_address("GameAssembly.dll").is_ok();
 
         let address = if is_64_bit {
             let addr = SIG_64_BIT.scan_process_range(process, unity_player)? + 7;
@@ -45,11 +49,14 @@ impl SceneManager {
         };
 
         let offsets = Offsets::new(is_64_bit);
+        let pointer_size = if is_64_bit { 0x8 } else { 0x4 };
 
         Some(Self {
             is_64_bit,
+            is_il2cpp,
             address,
             offsets,
+            pointer_size,
         })
     }
 
@@ -121,6 +128,236 @@ impl SceneManager {
             })
             .filter(move |p| !fptr.is_null() && p.is_valid(process))
     }
+
+    /// Iterates over all root `Transform`s / `GameObject`s declared for the current scene.
+    ///
+    /// Each Unity scene normally has a linked list of `Transform`s (each one is a `GameObject`).
+    /// Each one can, recursively, have a child `Transform` (and so on), and has a list of `Component`s, which are
+    /// classes (eg. `MonoBehaviour`) containing data we might want to retreieve for the autosplitter logic.
+    fn root_game_objects<'a>(
+        &'a self,
+        process: &'a Process,
+    ) -> Result<impl DoubleEndedIterator<Item = GameObject> + 'a, Error> {
+        let current_scene_address = self.get_current_scene_address(process)?;
+        let first_game_object = self.read_pointer(
+            process,
+            current_scene_address + self.offsets.root_storage_container,
+        )?;
+
+        let number_of_root_game_objects = {
+            let mut index: usize = 0;
+            let mut temp_tr = first_game_object;
+
+            while temp_tr != current_scene_address + self.offsets.root_storage_container {
+                index += 1;
+                temp_tr = self.read_pointer(process, temp_tr)?;
+            }
+
+            index
+        };
+
+        let mut current_game_object = first_game_object;
+
+        Ok((0..number_of_root_game_objects).filter_map(move |n| {
+            let buf: [Address; 3] = match self.is_64_bit {
+                true => process
+                    .read::<[Address64; 3]>(current_game_object)
+                    .ok()?
+                    .map(|a| a.into()),
+                false => process
+                    .read::<[Address32; 3]>(current_game_object)
+                    .ok()?
+                    .map(|a| a.into()),
+            };
+
+            let game_object = self
+                .read_pointer(process, buf[2] + self.offsets.game_object)
+                .ok()?;
+
+            // Load the next game object before looping, except at the last iteration of the loop
+            if n + 1 != number_of_root_game_objects {
+                current_game_object = buf[0];
+            }
+
+            Some(GameObject {
+                address: game_object,
+            })
+        }))
+    }
+
+    /// Tries to find the specified root `GameObject` in the current Unity scene.
+    pub fn get_root_game_object(&self, process: &Process, name: &str) -> Result<GameObject, Error> {
+        self.root_game_objects(process)?
+            .find(|obj| {
+                obj.get_name::<128>(process, self)
+                    .unwrap_or_default()
+                    .as_bytes()
+                    == name.as_bytes()
+            })
+            .ok_or(Error {})
+    }
+}
+
+/// A `GameObject` is a base class for all entities used in a Unity scene.
+/// All classes of interest useful for an autosplitter can be found starting from the addresses of the root `GameObject`s linked in each scene.
+pub struct GameObject {
+    address: Address,
+}
+
+impl GameObject {
+    /// Tries to return the name of the current `GameObject`
+    pub fn get_name<const N: usize>(
+        &self,
+        process: &Process,
+        scene_manager: &SceneManager,
+    ) -> Result<ArrayCString<N>, Error> {
+        let name_ptr = scene_manager.read_pointer(
+            process,
+            self.address + scene_manager.offsets.game_object_name,
+        )?;
+        process.read(name_ptr)
+    }
+
+    /// Iterates over the classes referred to in the current `GameObject`
+    pub fn classes<'a>(
+        &'a self,
+        process: &'a Process,
+        scene_manager: &'a SceneManager,
+    ) -> Result<impl Iterator<Item = Address> + 'a, Error> {
+        let number_of_components = process
+            .read::<u32>(self.address + scene_manager.offsets.number_of_object_components)?
+            as usize;
+
+        if number_of_components == 0 {
+            return Err(Error {});
+        }
+        
+        let main_object = scene_manager
+            .read_pointer(process, self.address + scene_manager.offsets.game_object)?;
+
+        const ARRAY_SIZE: usize = 128;
+        let mut components = [Address::NULL; ARRAY_SIZE];
+
+        if scene_manager.is_64_bit {
+            let slice = &mut [Address64::NULL; ARRAY_SIZE * 2][0..number_of_components * 2];
+            process.read_into_slice(main_object, slice)?;
+
+            for val in 0..number_of_components {
+                components[val] = slice[val * 2 + 1].into();
+            }
+        } else {
+            let slice = &mut [Address32::NULL; ARRAY_SIZE * 2][0..number_of_components * 2];
+            process.read_into_slice(main_object, slice)?;
+
+            for val in 0..number_of_components {
+                components[val] = slice[val * 2 + 1].into();
+            }
+        }
+
+        Ok((0..number_of_components).filter_map(move |m| {
+            scene_manager
+                .read_pointer(process, components[m] + scene_manager.offsets.klass)
+                .ok()
+        }))
+    }
+
+    /// Tries to find the base address of a class in the current `GameObject`
+    pub fn get_class(
+        &self,
+        process: &Process,
+        scene_manager: &SceneManager,
+        name: &str,
+    ) -> Result<Address, Error> {
+        self.classes(process, scene_manager)?.find(|&c| {
+            let Ok(vtable) = scene_manager.read_pointer(process, c) else { return false };
+
+            let name_ptr = {
+                match scene_manager.is_il2cpp {
+                    true => {
+                        let Ok(name_ptr) = scene_manager.read_pointer(process, vtable + scene_manager.pointer_size as u32 * 2) else { return false };
+                        name_ptr
+                    },
+                    false => {
+                        let Ok(vtable) = scene_manager.read_pointer(process, vtable) else { return false };
+                        let Ok(name_ptr) = scene_manager.read_pointer(process, vtable + scene_manager.offsets.klass_name) else { return false };
+                        name_ptr
+                    }
+                }
+            };
+
+            let Ok(class_name) = process.read::<ArrayCString<128>>(name_ptr) else { return false };
+            class_name.as_bytes() == name.as_bytes()
+        }).ok_or(Error {})
+    }
+
+    /// Iterates over children `GameObject`s referred by the current one
+    pub fn children<'a>(
+        &'a self,
+        process: &'a Process,
+        scene_manager: &'a SceneManager,
+    ) -> Result<impl Iterator<Item = Self> + 'a, Error> {
+        let main_object = scene_manager
+            .read_pointer(process, self.address + scene_manager.offsets.game_object)?;
+
+        let transform =
+            scene_manager.read_pointer(process, main_object + scene_manager.pointer_size)?;
+
+        let child_count =
+            process.read::<u32>(transform + scene_manager.offsets.children_count)? as usize;
+
+        if child_count == 0 {
+            return Err(Error {});
+        }
+
+        let child_pointer = scene_manager
+            .read_pointer(process, transform + scene_manager.offsets.children_pointer)?;
+
+        // Define an empty array and fill it later with the addresses of all child classes found for the current GameObject.
+        // Reading the whole array of pointers is (slightly) faster than reading each address in a loop
+        const ARRAY_SIZE: usize = 128;
+        let mut children = [Address::NULL; ARRAY_SIZE];
+
+        if scene_manager.is_64_bit {
+            let slice = &mut [Address64::NULL; ARRAY_SIZE][0..child_count];
+            process.read_into_slice(child_pointer, slice)?;
+
+            for val in 0..child_count {
+                children[val] = slice[val].into();
+            }
+        } else {
+            let slice = &mut [Address32::NULL; ARRAY_SIZE][0..child_count];
+            process.read_into_slice(child_pointer, slice)?;
+
+            for val in 0..child_count {
+                children[val] = slice[val].into();
+            }
+        }
+
+        Ok((0..child_count).filter_map(move |f| {
+            let game_object = scene_manager
+                .read_pointer(process, children[f] + scene_manager.offsets.game_object)
+                .ok()?;
+
+            Some(Self {
+                address: game_object,
+            })
+        }))
+    }
+
+    /// Tries to find a child `GameObject` from the current one.
+    pub fn get_child(
+        &self,
+        process: &Process,
+        scene_manager: &SceneManager,
+        name: &str,
+    ) -> Result<Self, Error> {
+        self.children(process, scene_manager)?
+            .find(|p| {
+                let Ok(obj_name) = p.get_name::<128>(process, scene_manager) else { return false };
+                obj_name.as_bytes() == name.as_bytes()
+            })
+            .ok_or(Error {})
+    }
 }
 
 struct Offsets {
@@ -129,6 +366,14 @@ struct Offsets {
     active_scene: u8,
     asset_path: u8,
     build_index: u8,
+    root_storage_container: u8,
+    game_object: u8,
+    game_object_name: u8,
+    number_of_object_components: u8,
+    klass: u8,
+    klass_name: u8,
+    children_count: u8,
+    children_pointer: u8,
 }
 
 impl Offsets {
@@ -140,6 +385,14 @@ impl Offsets {
                 active_scene: 0x48,
                 asset_path: 0x10,
                 build_index: 0x98,
+                root_storage_container: 0xB0,
+                game_object: 0x30,
+                game_object_name: 0x60,
+                number_of_object_components: 0x40,
+                klass: 0x28,
+                klass_name: 0x48,
+                children_count: 0x80,
+                children_pointer: 0x70,
             },
             false => &Self {
                 scene_count: 0xC,
@@ -147,6 +400,14 @@ impl Offsets {
                 active_scene: 0x28,
                 asset_path: 0xC,
                 build_index: 0x70,
+                root_storage_container: 0x88,
+                game_object: 0x1C,
+                game_object_name: 0x3C,
+                number_of_object_components: 0x24,
+                klass: 0x18,
+                klass_name: 0x2C,
+                children_count: 0x58,
+                children_pointer: 0x50,
             },
         }
     }


### PR DESCRIPTION
This commit enhances the functionality of the `SceneManager` for games using the Unity engine by giving the ability to look for addresses of classes with no static reference.

Traditionally, a static entry point is deemed necessary in order to easily access a certain instance of a class / struct in Unity games. However, the use of `Singleton`s and static references is becoming rare in modern games, as Unity devs reccommend attaching classes (especially `MonoBehaviour`s) to a game object referenced by the currently running Unity scene.

To put it simply, each Unity scene has a linked `List` of game objects called `Transform`s, with each one having, recursively, a child `Transform`, and an array of `Component` classes, which contain the data usually needed for the autosplitting logic.

As the lack of a static reference makes it impossible to have an easy way to access those classes, the code added in this commit will provide a solution.
However, whenever possible, using a static reference shoould still be preferred, as searching through unity `GameObject`s is a fairly memory expensive operation (roughly 5-6 times slower).

Hierarchy and inheritance can be looked for at runtime using Micrologist's [UnityInstanceDumper](https://github.com/Micrologist/UnityInstanceDumper).

The example provided here recovers the in-game timer from the game Wretched Depths (freely available on Steam):
```rust
let scene_manager = game_engine::unity::SceneManager::wait_attach(&process).await;

loop { 
    let mut time: f32 = 0.0;

    // Accessing the main game object attached to the current scene
    if let Ok(in_game_systems) = scene_manager.get_root_game_object(&process, "InGameSystems") {
        // Accessing the child Transform named "Managers"
        if let Ok(managers) = in_game_systems.get_child(&process, &scene_manager, "Managers") {
            // Yet another child Transform with a pretty obvious name
            if let Ok(game_manager) = managers.get_child(&process, &scene_manager, "GameManager") {
                // Our class, named "GameManager", is referenced directly by the current GameObject
                if let Ok(game_manager) = game_manager.get_class(&process, &scene_manager, "GameManager") {
                    if let Ok(t_time) = process.read::<f32>(game_manager + 0x3C) {
                        time = t_time;
                    }
                }
            }
        }
    }

    timer::set_game_time(Duration::seconds_f32(time));
    next_tick().await;
}
```