### PR TITLE
Add Process Listing and Attach by PID

### DIFF
--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -43,9 +43,7 @@ impl Process {
     /// Attaches to a process based on its pid.
     #[inline]
     pub fn attach_pid(pid: u32) -> Option<Self> {
-        // SAFETY: We provide a valid pointer and length to the name. The name
-        // is guaranteed to be valid UTF-8. We also do proper error handling
-        // afterwards.
+        // SAFETY: We do proper error handling afterwards.
         let id = unsafe { sys::process_attach_pid(pid) };
         id.map(Self)
     }
@@ -53,6 +51,10 @@ impl Process {
     #[cfg(feature = "alloc")]
     #[inline]
     pub fn list(name: &str) -> Option<alloc::vec::Vec<u32>> {
+        // SAFETY: We provide a valid pointer and length to the name. The name
+        // is guaranteed to be valid UTF-8. Calling `list` with a null pointer 
+        // and 0 length will return the required length. We then allocate a 
+        // buffer with the required length and call it again with the buffer.
         unsafe { 
             let mut len = 0;
             let empty = sys::process_list(name.as_ptr(), name.len(), core::ptr::null_mut(), &mut len);

--- a/src/runtime/sys.rs
+++ b/src/runtime/sys.rs
@@ -60,8 +60,12 @@ extern "C" {
 
     /// Attaches to a process based on its name.
     pub fn process_attach(name_ptr: *const u8, name_len: usize) -> Option<ProcessId>;
+    /// Attaches to a process based on its pid.
+    pub fn process_attach_pid(pid: u32) -> Option<ProcessId>;
     /// Detaches from a process.
     pub fn process_detach(process: ProcessId);
+    /// 
+    pub fn process_list(name_ptr: *const u8, name_len: usize, list_ptr: *mut u8, list_len_ptr: *mut usize) -> bool;
     /// Checks whether is a process is still open. You should detach from a
     /// process and stop using it if this returns `false`.
     pub fn process_is_open(process: ProcessId) -> bool;

--- a/src/runtime/sys.rs
+++ b/src/runtime/sys.rs
@@ -64,7 +64,11 @@ extern "C" {
     pub fn process_attach_pid(pid: u32) -> Option<ProcessId>;
     /// Detaches from a process.
     pub fn process_detach(process: ProcessId);
-    /// 
+    /// Lists processes (as pids) based on their name. Returns `false` 
+    /// if the buffer is too small. After this call, no matter whether
+    /// it was successful or not, the `buf_len_ptr` will be set to the
+    /// required buffer size. 
+    #[cfg(feature = "alloc")]
     pub fn process_list(name_ptr: *const u8, name_len: usize, list_ptr: *mut u8, list_len_ptr: *mut usize) -> bool;
     /// Checks whether is a process is still open. You should detach from a
     /// process and stop using it if this returns `false`.

--- a/src/runtime/sys.rs
+++ b/src/runtime/sys.rs
@@ -8,7 +8,15 @@ pub struct NonZeroAddress(pub NonZeroU64);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct ProcessId(NonZeroU64);
+pub struct Process(NonZeroU64);
+
+/// A process id is a unique identifier for a process. It is not guaranteed to
+/// be the same across multiple runs of the same process. It is only guaranteed
+/// to be unique for the duration of the process. This matches the operating
+/// system's definition of a process id.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct ProcessId(pub u64);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(transparent)]
@@ -59,24 +67,35 @@ extern "C" {
     pub fn timer_resume_game_time();
 
     /// Attaches to a process based on its name.
-    pub fn process_attach(name_ptr: *const u8, name_len: usize) -> Option<ProcessId>;
-    /// Attaches to a process based on its pid.
-    pub fn process_attach_pid(pid: u32) -> Option<ProcessId>;
+    pub fn process_attach(name_ptr: *const u8, name_len: usize) -> Option<Process>;
+    /// Attaches to a process based on its process id.
+    pub fn process_attach_by_pid(pid: ProcessId) -> Option<Process>;
     /// Detaches from a process.
-    pub fn process_detach(process: ProcessId);
-    /// Lists processes (as pids) based on their name. Returns `false` 
-    /// if the buffer is too small. After this call, no matter whether
-    /// it was successful or not, the `buf_len_ptr` will be set to the
-    /// required buffer size. 
-    #[cfg(feature = "alloc")]
-    pub fn process_list(name_ptr: *const u8, name_len: usize, list_ptr: *mut u8, list_len_ptr: *mut usize) -> bool;
+    pub fn process_detach(process: Process);
+    /// Lists processes based on their name. Returns `false` if listing the
+    /// processes failed. If it was successful, the buffer is now filled
+    /// with the process ids. They are in no specific order. The
+    /// `list_len_ptr` will be updated to the amount of process ids that
+    /// were found. If this is larger than the original value provided, the
+    /// buffer provided was too small and not all process ids could be
+    /// stored. This is still considered successful and can optionally be
+    /// treated as an error condition by the caller by checking if the
+    /// length increased and potentially reallocating a larger buffer. If
+    /// the length decreased after the call, the buffer was larger than
+    /// needed and the remaining entries are untouched.
+    pub fn process_list_by_name(
+        name_ptr: *const u8,
+        name_len: usize,
+        list_ptr: *mut ProcessId,
+        list_len_ptr: *mut usize,
+    ) -> bool;
     /// Checks whether is a process is still open. You should detach from a
     /// process and stop using it if this returns `false`.
-    pub fn process_is_open(process: ProcessId) -> bool;
+    pub fn process_is_open(process: Process) -> bool;
     /// Reads memory from a process at the address given. This will write
     /// the memory to the buffer given. Returns `false` if this fails.
     pub fn process_read(
-        process: ProcessId,
+        process: Process,
         address: Address,
         buf_ptr: *mut u8,
         buf_len: usize,
@@ -84,30 +103,29 @@ extern "C" {
 
     /// Gets the address of a module in a process.
     pub fn process_get_module_address(
-        process: ProcessId,
+        process: Process,
         name_ptr: *const u8,
         name_len: usize,
     ) -> Option<NonZeroAddress>;
     /// Gets the size of a module in a process.
     pub fn process_get_module_size(
-        process: ProcessId,
+        process: Process,
         name_ptr: *const u8,
         name_len: usize,
     ) -> Option<NonZeroU64>;
 
     #[cfg(feature = "alloc")]
-    pub fn process_get_path(process: ProcessId, buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
+    pub fn process_get_path(process: Process, buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 
     /// Gets the number of memory ranges in a given process.
-    pub fn process_get_memory_range_count(process: ProcessId) -> Option<NonZeroU64>;
+    pub fn process_get_memory_range_count(process: Process) -> Option<NonZeroU64>;
     /// Gets the start address of a memory range by its index.
-    pub fn process_get_memory_range_address(process: ProcessId, idx: u64)
-        -> Option<NonZeroAddress>;
+    pub fn process_get_memory_range_address(process: Process, idx: u64) -> Option<NonZeroAddress>;
     /// Gets the size of a memory range by its index.
-    pub fn process_get_memory_range_size(process: ProcessId, idx: u64) -> Option<NonZeroU64>;
+    pub fn process_get_memory_range_size(process: Process, idx: u64) -> Option<NonZeroU64>;
     /// Gets the flags of a memory range by its index.
     #[cfg(feature = "flags")]
-    pub fn process_get_memory_range_flags(process: ProcessId, idx: u64) -> Option<NonZeroU64>;
+    pub fn process_get_memory_range_flags(process: Process, idx: u64) -> Option<NonZeroU64>;
 
     /// Sets the tick rate of the runtime. This influences the amount of
     /// times the `update` function is called per second.


### PR DESCRIPTION
Adds two functions:

`Process::attach_pid` attaches to a process by referencing its PID.
`Process::list` lists all PIDs associated with processes with the name passed in.

Together, these allow an autosplitter to define its own logic for discovering and attaching to processes.  

Sometimes start time or largest PID don't quite get the right process.  For example, Tony Hawk's Pro Skater 1+2 has a bootstrap and game process, both with the same name.  They start in the same second, so the regular `Process::attach` logic often selects the incorrect process.  This pull request allows an author to check each process closer to determine which one is desired.  (rather messy) example of usage here: https://github.com/PARTYMANX/thps-autosplitter/blob/thps12-disambiguate/src/lib.rs#L19

Companion pull request to https://github.com/LiveSplit/livesplit-core/pull/721.  Solves #50.