### PR TITLE
Support Mac for Unity / Mono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ libm = { version = "0.2.7", optional = true }
 wasi = { version = "0.11.0+wasi-snapshot-preview1", default-features = false }
 
 [features]
+std = ["alloc"]
 alloc = []
 derive = ["asr-derive"]
 flags = ["bitflags"]

--- a/src/file_format/macho.rs
+++ b/src/file_format/macho.rs
@@ -1,0 +1,123 @@
+//! Support for parsing MachO files
+
+use crate::{Process, Address};
+
+use core::mem;
+
+// Magic mach-o header constants from:
+// https://opensource.apple.com/source/xnu/xnu-4570.71.2/EXTERNAL_HEADERS/mach-o/loader.h.auto.html
+const MH_MAGIC_32: u32 = 0xfeedface;
+const MH_CIGAM_32: u32 = 0xcefaedfe;
+const MH_MAGIC_64: u32 = 0xfeedfacf;
+const MH_CIGAM_64: u32 = 0xcffaedfe;
+
+struct MachOFormatOffsets {
+    number_of_commands: usize,
+    load_commands: usize,
+    command_size: usize,
+    symbol_table_offset: usize,
+    number_of_symbols: usize,
+    string_table_offset: usize,
+    nlist_value: usize,
+    size_of_nlist_item: usize,
+}
+
+impl MachOFormatOffsets {
+    const fn new() -> Self {
+        // offsets taken from:
+        //  - https://github.com/hackf5/unityspy/blob/master/src/HackF5.UnitySpy/Offsets/MachOFormatOffsets.cs
+        //  - https://opensource.apple.com/source/xnu/xnu-4570.71.2/EXTERNAL_HEADERS/mach-o/loader.h.auto.html
+        MachOFormatOffsets {
+            number_of_commands: 0x10,
+            load_commands: 0x20,
+            command_size: 0x04,
+            symbol_table_offset: 0x08,
+            number_of_symbols: 0x0c,
+            string_table_offset: 0x10,
+            nlist_value: 0x08,
+            size_of_nlist_item: 0x10,
+        }
+    }
+}
+
+/// Scans the range for a page that begins with MachO Magic
+pub fn scan_macho_page(process: &Process, range: (Address, u64)) -> Option<Address> {
+    const PAGE_SIZE: u64 = 0x1000;
+    let (addr, len) = range;
+    // negation mod PAGE_SIZE
+    let distance_to_page = (PAGE_SIZE - (addr.value() % PAGE_SIZE)) % PAGE_SIZE;
+    // round up to the next multiple of PAGE_SIZE
+    let first_page = addr + distance_to_page;
+    for i in 0..((len - distance_to_page) / PAGE_SIZE) {
+        let a = first_page + (i * PAGE_SIZE);
+        match process.read::<u32>(a) {
+            Ok(MH_MAGIC_64 | MH_CIGAM_64 | MH_MAGIC_32 | MH_CIGAM_32) => {
+                return Some(a);
+            }
+            _ => ()
+        }
+    }
+    None
+}
+
+/// Determines whether a MachO header at the address is 64-bit or 32-bit
+pub fn is_64_bit(process: &Process, address: Address) -> Option<bool> {
+    let magic: u32 = process.read(address).ok()?;
+    match magic {
+        MH_MAGIC_64 | MH_CIGAM_64 => Some(true),
+        MH_MAGIC_32 | MH_CIGAM_32 => Some(false),
+        _ => None
+    }
+}
+
+/// Finds the address of a function from a MachO module range and file contents.
+pub fn get_function_address(process: &Process, range: (Address, u64), macho_bytes: &[u8], function_name: &[u8]) -> Option<Address> {
+    let function_offset: u32 = get_function_offset(&macho_bytes, function_name)?;
+    let function_address = scan_macho_page(process, range)? + function_offset;
+    let actual: [u8; 0x100] = process.read(function_address).ok()?;
+    let expected: [u8; 0x100] = slice_read(&macho_bytes, function_offset as usize).ok()?;
+    if actual != expected { return None; }
+    Some(function_address)
+}
+
+/// Finds the offset of a function in the bytes of a MachO file.
+pub fn get_function_offset(macho_bytes: &[u8], function_name: &[u8]) -> Option<u32> {
+    let macho_offsets = MachOFormatOffsets::new();
+    let number_of_commands: u32 = slice_read(macho_bytes, macho_offsets.number_of_commands).ok()?;
+    let function_name_len = function_name.len();
+
+    let mut offset_to_next_command: usize = macho_offsets.load_commands as usize;
+    for _i in 0..number_of_commands {
+        // Check if load command is LC_SYMTAB
+        let next_command: i32 = slice_read(macho_bytes, offset_to_next_command).ok()?;
+        if next_command == 2 {
+            let symbol_table_offset: u32 = slice_read(macho_bytes, offset_to_next_command + macho_offsets.symbol_table_offset).ok()?;
+            let number_of_symbols: u32 = slice_read(macho_bytes, offset_to_next_command + macho_offsets.number_of_symbols).ok()?;
+            let string_table_offset: u32 = slice_read(macho_bytes, offset_to_next_command + macho_offsets.string_table_offset).ok()?;
+
+            for j in 0..(number_of_symbols as usize) {
+                let symbol_name_offset: u32 = slice_read(macho_bytes, symbol_table_offset as usize + (j * macho_offsets.size_of_nlist_item)).ok()?;
+                let string_offset = string_table_offset as usize + symbol_name_offset as usize;
+                let symbol_name: &[u8] = &macho_bytes[string_offset..(string_offset + function_name_len + 1)];
+
+                if symbol_name[function_name_len] == 0 && symbol_name.starts_with(function_name) {
+                    return Some(slice_read(macho_bytes, symbol_table_offset as usize + (j * macho_offsets.size_of_nlist_item) + macho_offsets.nlist_value).ok()?);
+                }
+            }
+
+            break;
+        } else {
+            let command_size: u32 = slice_read(macho_bytes, offset_to_next_command + macho_offsets.command_size).ok()?;
+            offset_to_next_command += command_size as usize;
+        }
+    }
+    None
+}
+
+/// Reads a value of the type specified from the slice at the address
+/// given.
+pub fn slice_read<T: bytemuck::CheckedBitPattern>(slice: &[u8], address: usize) -> Result<T, bytemuck::checked::CheckedCastError> {
+    let size = mem::size_of::<T>();
+    let slice_src = &slice[address..(address + size)];
+    bytemuck::checked::try_from_bytes(slice_src).cloned()
+}

--- a/src/file_format/macho.rs
+++ b/src/file_format/macho.rs
@@ -1,6 +1,6 @@
 //! Support for parsing MachO files
 
-use crate::{Process, Address};
+use crate::{Address, PointerSize, Process};
 
 use core::mem;
 
@@ -61,11 +61,11 @@ pub fn scan_macho_page(process: &Process, range: (Address, u64)) -> Option<Addre
 }
 
 /// Determines whether a MachO header at the address is 64-bit or 32-bit
-pub fn is_64_bit(process: &Process, address: Address) -> Option<bool> {
+pub fn pointer_size(process: &Process, address: Address) -> Option<PointerSize> {
     let magic: u32 = process.read(address).ok()?;
     match magic {
-        MH_MAGIC_64 | MH_CIGAM_64 => Some(true),
-        MH_MAGIC_32 | MH_CIGAM_32 => Some(false),
+        MH_MAGIC_64 | MH_CIGAM_64 => Some(PointerSize::Bit64),
+        MH_MAGIC_32 | MH_CIGAM_32 => Some(PointerSize::Bit32),
         _ => None
     }
 }

--- a/src/file_format/mod.rs
+++ b/src/file_format/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod elf;
 pub mod pe;
+pub mod macho;

--- a/src/game_engine/unity/mono.rs
+++ b/src/game_engine/unity/mono.rs
@@ -65,13 +65,7 @@ impl Module {
                 }
             }
             #[cfg(feature = "std")]
-            BinaryFormat::MachO => {
-                if macho::is_64_bit(process, macho::scan_macho_page(process, module_range)?)? {
-                    PointerSize::Bit64
-                } else {
-                    PointerSize::Bit32
-                }
-            }
+            BinaryFormat::MachO => macho::pointer_size(process, macho::scan_macho_page(process, module_range)?)?,
         };
         let offsets = Offsets::new(version, pointer_size, format)?;
 

--- a/src/game_engine/unity/mono.rs
+++ b/src/game_engine/unity/mono.rs
@@ -841,25 +841,27 @@ impl Offsets {
                     monovtable_vtable: 0x48,
                     monoclassfieldalignment: 0x20,
                 }),
+                // 64-bit PE V2 matches Unity2019_4_2020_3_x64_PE_Offsets from
+                // https://github.com/hackf5/unityspy/blob/master/src/HackF5.UnitySpy/Offsets/MonoLibraryOffsets.cs#L49
                 Version::V2 => Some(&Self {
                     monoassembly_aname: 0x10,
-                    monoassembly_image: 0x60,
-                    monoimage_class_cache: 0x4C0,
-                    monointernalhashtable_table: 0x20,
-                    monointernalhashtable_size: 0x18,
-                    monoclassdef_next_class_cache: 0x108,
+                    monoassembly_image: 0x60, // AssemblyImage = 0x44 + 0x1c
+                    monoimage_class_cache: 0x4C0, // ImageClassCache = 0x354 + 0x16c
+                    monointernalhashtable_table: 0x20, // HashTableTable = 0x14 + 0xc
+                    monointernalhashtable_size: 0x18, // HashTableSize = 0xc + 0xc
+                    monoclassdef_next_class_cache: 0x108, // TypeDefinitionNextClassCache = 0xa8 + 0x34 + 0x10 + 0x18 + 0x4
                     monoclassdef_klass: 0x0,
-                    monoclass_name: 0x48,
-                    monoclass_name_space: 0x50,
-                    monoclass_fields: 0x98,
-                    monoclassdef_field_count: 0x100,
-                    monoclass_runtime_info: 0xD0,
-                    monoclass_vtable_size: 0x5C,
-                    monoclass_parent: 0x30,
+                    monoclass_name: 0x48, // TypeDefinitionName = 0x2c + 0x1c
+                    monoclass_name_space: 0x50, // TypeDefinitionNamespace = 0x30 + 0x20
+                    monoclass_fields: 0x98, // TypeDefinitionFields = 0x60 + 0x20 + 0x18
+                    monoclassdef_field_count: 0x100, // TypeDefinitionFieldCount = 0xa4 + 0x34 + 0x10 + 0x18
+                    monoclass_runtime_info: 0xD0, // TypeDefinitionRuntimeInfo = 0x84 + 0x34 + 0x18
+                    monoclass_vtable_size: 0x5C, // TypeDefinitionVTableSize = 0x38 + 0x24
+                    monoclass_parent: 0x30, // TypeDefinitionParent = 0x20 + 0x10
                     monoclassfield_name: 0x8,
                     monoclassfield_offset: 0x18,
-                    monoclassruntimeinfo_domain_vtables: 0x8,
-                    monovtable_vtable: 0x40,
+                    monoclassruntimeinfo_domain_vtables: 0x8, // TypeDefinitionRuntimeInfoDomainVTables = 0x4 + 0x4
+                    monovtable_vtable: 0x40, // VTable = 0x28 + 0x18
                     monoclassfieldalignment: 0x20,
                 }),
                 Version::V3 => Some(&Self {
@@ -905,26 +907,28 @@ impl Offsets {
                     monoclassruntimeinfo_domain_vtables: 0x4,
                     monovtable_vtable: 0x28,
                     monoclassfieldalignment: 0x10,
+                // 32-bit PE V2 matches Unity2018_4_10_x86_PE_Offsets from
+                // https://github.com/hackf5/unityspy/blob/master/src/HackF5.UnitySpy/Offsets/MonoLibraryOffsets.cs#L12
                 }),
                 Version::V2 => Some(&Self {
                     monoassembly_aname: 0x8,
-                    monoassembly_image: 0x44,
-                    monoimage_class_cache: 0x354,
-                    monointernalhashtable_table: 0x14,
-                    monointernalhashtable_size: 0xC,
-                    monoclassdef_next_class_cache: 0xA8,
+                    monoassembly_image: 0x44, // AssemblyImage
+                    monoimage_class_cache: 0x354, // ImageClassCache
+                    monointernalhashtable_table: 0x14, // HashTableTable
+                    monointernalhashtable_size: 0xC, // HashTableSize
+                    monoclassdef_next_class_cache: 0xA8, // TypeDefinitionNextClassCache
                     monoclassdef_klass: 0x0,
-                    monoclass_name: 0x2C,
-                    monoclass_name_space: 0x30,
-                    monoclass_fields: 0x60,
-                    monoclassdef_field_count: 0xA4,
-                    monoclass_runtime_info: 0x84,
-                    monoclass_vtable_size: 0x38,
-                    monoclass_parent: 0x20,
+                    monoclass_name: 0x2C, // TypeDefinitionName
+                    monoclass_name_space: 0x30, // TypeDefinitionNamespace
+                    monoclass_fields: 0x60, // TypeDefinitionFields
+                    monoclassdef_field_count: 0xA4, // TypeDefinitionFieldCount
+                    monoclass_runtime_info: 0x84, // TypeDefinitionRuntimeInfo
+                    monoclass_vtable_size: 0x38, // TypeDefinitionVTableSize
+                    monoclass_parent: 0x20, // TypeDefinitionParent
                     monoclassfield_name: 0x4,
                     monoclassfield_offset: 0xC,
-                    monoclassruntimeinfo_domain_vtables: 0x4,
-                    monovtable_vtable: 0x28,
+                    monoclassruntimeinfo_domain_vtables: 0x4, // TypeDefinitionRuntimeInfoDomainVTables
+                    monovtable_vtable: 0x28, // VTable
                     monoclassfieldalignment: 0x10,
                 }),
                 Version::V3 => Some(&Self {

--- a/src/game_engine/unity/scene.rs
+++ b/src/game_engine/unity/scene.rs
@@ -48,13 +48,7 @@ impl SceneManager {
                     _ => PointerSize::Bit32,
                 }
             }
-            BinaryFormat::MachO => {
-                if macho::is_64_bit(process, macho::scan_macho_page(process, unity_player)?)? {
-                    PointerSize::Bit64
-                } else {
-                    PointerSize::Bit32
-                }
-            }
+            BinaryFormat::MachO => macho::pointer_size(process, macho::scan_macho_page(process, unity_player)?)?,
         };
         let is_il2cpp = process.get_module_address("GameAssembly.dll").is_ok();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
     clippy::complexity,
     clippy::correctness,


### PR DESCRIPTION
This adds Mac support to `asr::game_engine::unity::SceneManager` and `asr::game_engine::unity::mono`.

The `SceneManager` support does not rely on `std`, but the `mono` support does need `std`, which can be activated with the `std` feature.

During development at `Image classes table detect cycles`, I got cycles in the classes iterator, which I had to detect and break. But at `Offsets for 64-bit MachO V2`, I found the cause of those cycles was the wrong offset for `monoclassdef_next_class_cache`. It should have been using `0x100` as the offset to that, but had been incorrectly using `0x108` as the offset.