### PR TITLE
[Unity] Automatic pointer path resolution for Mono games

### DIFF
--- a/src/game_engine/unity/il2cpp.rs
+++ b/src/game_engine/unity/il2cpp.rs
@@ -396,22 +396,15 @@ impl<const CAP: usize> Pointer<CAP> {
     pub fn new(class_name: &str, nr_of_parents: u8, fields: &[&str]) -> Self {
         assert!(!fields.is_empty() && fields.len() <= CAP);
 
-        let mut this_class_name = ArrayString::new();
-        this_class_name.push_str(class_name);
-
-        let mut this_fields = ArrayVec::new();
-        for &val in fields {
-            let mut string = ArrayString::new();
-            string.push_str(val);
-            this_fields.push(string);
-        }
-
         Self {
             static_table: OnceCell::new(),
             offsets: OnceCell::new(),
-            class_name: this_class_name,
+            class_name: ArrayString::from(class_name).unwrap_or_default(),
             nr_of_parents,
-            fields: this_fields,
+            fields: fields
+                .iter()
+                .map(|&val| ArrayString::from(val).unwrap_or_default())
+                .collect(),
         }
     }
 

--- a/src/game_engine/unity/il2cpp.rs
+++ b/src/game_engine/unity/il2cpp.rs
@@ -1,6 +1,6 @@
 //! Support for attaching to Unity games that are using the IL2CPP backend.
 
-use core::cmp::Ordering;
+use core::{cell::OnceCell, cmp::Ordering};
 
 use crate::{
     file_format::pe, future::retry, signature::Signature, string::ArrayCString, Address, Address32,
@@ -378,87 +378,73 @@ impl Class {
 }
 
 /// An IL2CPP-specific implementation for automatic pointer path resolution
-pub struct Pointer<const N: usize> {
-    static_table: Option<Address>,
-    offsets: [u32; N],
-    is_64_bit: bool,
+pub struct Pointer<'a, const N: usize> {
+    static_table: OnceCell<Address>,
+    offsets: OnceCell<[u32; N]>,
+    il2cpp_module: &'a Module,
+    il2cpp_image: &'a Image,
+    class_name: &'a str,
+    nr_of_parents: u8,
+    fields: &'a [&'a str],
 }
 
-impl<const N: usize> Pointer<N> {
+impl<'a, const N: usize> Pointer<'a, N> {
     /// Creates a new instance of the Pointer struct
-    pub const fn new() -> Self {
+    pub const fn new(
+        module: &'a Module,
+        image: &'a Image,
+        class_name: &'a str,
+        nr_of_parents: u8,
+        fields: &'a [&'a str],
+    ) -> Self {
+        assert!(fields.len() == N && N != 0);
+
         Self {
-            static_table: None,
-            offsets: [0; N],
-            is_64_bit: false,
+            static_table: OnceCell::new(),
+            offsets: OnceCell::new(),
+            il2cpp_module: module,
+            il2cpp_image: image,
+            class_name,
+            nr_of_parents,
+            fields,
         }
     }
 
-    /// Tries to resolve the internally stored address of the Mono class
-    /// Returns `true` if the pointer path has been resolved, `false` otherwise.
-    pub fn try_find(
-        &mut self,
-        process: &Process,
-        module: &Module,
-        image: &Image,
-        class_name: &str,
-        no_of_parents: u32,
-        fields: &[&str],
-    ) -> bool {
-        match self.static_table {
-            None => self.force_find(process, module, image, class_name, no_of_parents, fields),
-            _ => true,
-        }
-    }
-
-    /// Tries to resolve the pointer path for the `IL2CPP` class specified, even if a pointer path has been already found.
-    ///
-    /// Returns `true` if the pointer path has been resolved, `false` otherwise.
-    pub fn force_find(
-        &mut self,
-        process: &Process,
-        module: &Module,
-        image: &Image,
-        class_name: &str,
-        no_of_parents: u32,
-        fields: &[&str],
-    ) -> bool {
-        assert!(fields.len() == N);
-
-        // If this function runs, for whatever reason, the address of the static table must be invalidated
-        self.static_table = None;
-
-        // Finding the first class in the hierarchy from which we will build our pointer path
-        let Some(mut current_class) = image.get_class(process, module, class_name) else {
-            return false;
-        };
-
-        // Looping through all the needed parent classes, according to the number specified in the function argument
-        for _ in 0..no_of_parents {
-            let Some(parent_class) = current_class.get_parent(process, module) else {
-                return false;
-            };
-            current_class = parent_class;
+    /// Tries to resolve the pointer path for the `IL2CPP` class specified
+    fn find_offsets(&self, process: &Process) -> Result<(), Error> {
+        // This function should not be called if the static table of the offsets have already been found
+        if self.static_table.get().is_some() || self.offsets.get().is_some() {
+            return Err(Error {});
         }
 
-        let Some(static_table) = current_class.get_static_table(process, module) else {
-            return false;
-        };
+        let mut current_class = self
+            .il2cpp_image
+            .get_class(process, self.il2cpp_module, self.class_name)
+            .ok_or(Error {})?;
 
-        let mut new_offsets = [0; N];
+        for _ in 0..self.nr_of_parents {
+            current_class = current_class
+                .get_parent(process, self.il2cpp_module)
+                .ok_or(Error {})?;
+        }
 
-        for i in 0..N {
+        let static_table = current_class
+            .get_static_table(process, self.il2cpp_module)
+            .ok_or(Error {})?;
+        let mut offsets = [0; N];
+
+        for (i, &field_name) in self.fields.iter().enumerate() {
             // Try to parse the offset, passed as a string, as an actual hex or decimal value
             let offset_from_string = {
                 let mut temp_val = None;
 
-                if fields[i].starts_with("0x") && fields[i].len() > 2 {
-                    if let Some(hex_val) = fields[i].get(2..fields[i].len()) {
+                if field_name.starts_with("0x") && field_name.len() > 2 {
+                    if let Some(hex_val) = field_name.get(2..field_name.len()) {
                         if let Ok(val) = u32::from_str_radix(hex_val, 16) {
                             temp_val = Some(val)
                         }
                     }
-                } else if let Ok(val) = fields[i].parse::<u32>() {
+                } else if let Ok(val) = field_name.parse::<u32>() {
                     temp_val = Some(val)
                 }
                 temp_val
@@ -466,88 +452,79 @@ impl<const N: usize> Pointer<N> {
 
             // Then we try finding the MonoClassField of interest, which is needed if we only provided the name of the field,
             // and will be needed anyway when looking for the next offset.
-            let Some(target_field) = current_class.fields(process, module).find(|&field| {
-                if let Some(val) = offset_from_string {
-                    process
-                        .read::<u32>(field + module.offsets.monoclassfield_offset)
-                        .is_ok_and(|value| value == val)
-                } else {
-                    module
-                        .read_pointer(process, field + module.offsets.monoclassfield_name)
-                        .is_ok_and(|name_addr|
-                            process.read::<ArrayCString<128>>(name_addr)
-                            .is_ok_and(|name|
-                                name.matches(fields[i])))
-                }
-            }) else { return false };
+            let target_field = current_class
+                .fields(process, self.il2cpp_module)
+                .find(|&field| {
+                    if let Some(val) = offset_from_string {
+                        process
+                            .read::<u32>(field + self.il2cpp_module.offsets.monoclassfield_offset)
+                            .is_ok_and(|value| value == val)
+                    } else {
+                        self.il2cpp_module
+                            .read_pointer(
+                                process,
+                                field + self.il2cpp_module.offsets.monoclassfield_name,
+                            )
+                            .is_ok_and(|name_addr| {
+                                process
+                                    .read::<ArrayCString<128>>(name_addr)
+                                    .is_ok_and(|name| name.matches(field_name))
+                            })
+                    }
+                })
+                .ok_or(Error {})?;
 
-            new_offsets[i] = if let Some(val) = offset_from_string {
-                val
-            } else if let Ok(val) =
-                process.read::<u32>(target_field + module.offsets.monoclassfield_offset)
-            {
+            offsets[i] = if let Some(val) = offset_from_string {
                 val
             } else {
-                return false;
+                process
+                    .read::<u32>(target_field + self.il2cpp_module.offsets.monoclassfield_offset)?
             };
 
             // In every iteration of the loop, except the last one, we then need to find the Class address for the next offset
             if i != N - 1 {
-                let Ok(r#type) = module.read_pointer(process, target_field + module.size_of_ptr()) else {
-                    return false;
-                };
-                let Ok(type_definition) = module.read_pointer(process, r#type) else {
-                    return false;
-                };
+                let r#type = self
+                    .il2cpp_module
+                    .read_pointer(process, target_field + self.il2cpp_module.size_of_ptr())?;
+                let type_definition = self.il2cpp_module.read_pointer(process, r#type)?;
+                let mut classes = self.il2cpp_image.classes(process, self.il2cpp_module)?;
 
-                let Ok(mut classes) = image.classes(process, module) else {
-                    return false;
-                };
-
-                let Some(new_class) = classes.find(|c| {
-                        module
+                let new_class = classes
+                    .find(|c| {
+                        self.il2cpp_module
                             .read_pointer(
                                 process,
-                                c.class + module.offsets.monoclass_type_definition,
+                                c.class + self.il2cpp_module.offsets.monoclass_type_definition,
                             )
                             .is_ok_and(|val| val == type_definition)
-                    }
-                ) else {
-                    return false;
-                };
+                    })
+                    .ok_or(Error {})?;
 
                 current_class = new_class;
             }
         }
 
-        self.is_64_bit = module.is_64_bit;
-        self.offsets = new_offsets;
-        self.static_table = Some(static_table);
-        true
+        let _ = self.offsets.set(offsets);
+        let _ = self.static_table.set(static_table);
+        Ok(())
     }
 
-    /// Reads a value from the cached pointer path
+    /// Reads a value, resolving the pointer path if needed
     pub fn read<T: CheckedBitPattern>(&self, process: &Process) -> Result<T, Error> {
-        let Some(mut address) = self.static_table else { return Err(Error {}) };
-        let depth = self.offsets.len();
-
-        if depth == 0 {
-            return process.read(address);
+        if self.static_table.get().is_none() {
+            self.find_offsets(process)?;
         }
 
-        for offset in 0..depth {
-            if offset != depth - 1 {
-                address = match self.is_64_bit {
-                    true => process
-                        .read::<Address64>(address + self.offsets[offset])?
-                        .into(),
-                    false => process
-                        .read::<Address32>(address + self.offsets[offset])?
-                        .into(),
-                };
-            }
+        let mut address = *self.static_table.get().ok_or(Error {})?;
+        let offsets = self.offsets.get().ok_or(Error {})?;
+
+        for &offset in offsets.iter().take(N - 1) {
+            address = match self.il2cpp_module.is_64_bit {
+                true => process.read::<Address64>(address.add(offset as _))?.into(),
+                false => process.read::<Address32>(address.add(offset as _))?.into(),
+            };
         }
-        process.read(address + self.offsets[depth - 1])
+        process.read(address + offsets[N - 1])
     }
 }
 

--- a/src/game_engine/unity/il2cpp.rs
+++ b/src/game_engine/unity/il2cpp.rs
@@ -7,6 +7,8 @@ use crate::{
     Address64, Error, Process,
 };
 
+use bytemuck::CheckedBitPattern;
+
 #[cfg(feature = "derive")]
 pub use asr_derive::Il2cppClass as Class;
 
@@ -375,6 +377,180 @@ impl Class {
     }
 }
 
+/// An IL2CPP-specific implementation for automatic pointer path resolution
+pub struct Pointer<const N: usize> {
+    static_table: Option<Address>,
+    offsets: [u32; N],
+    is_64_bit: bool,
+}
+
+impl<const N: usize> Pointer<N> {
+    /// Creates a new instance of the Pointer struct
+    pub const fn new() -> Self {
+        Self {
+            static_table: None,
+            offsets: [0; N],
+            is_64_bit: false,
+        }
+    }
+
+    /// Tries to resolve the internally stored address of the Mono class
+    /// Returns `true` if the pointer path has been resolved, `false` otherwise.
+    pub fn try_find(
+        &mut self,
+        process: &Process,
+        module: &Module,
+        image: &Image,
+        class_name: &str,
+        no_of_parents: u32,
+        fields: &[&str],
+    ) -> bool {
+        match self.static_table {
+            None => self.force_find(process, module, image, class_name, no_of_parents, fields),
+            _ => true,
+        }
+    }
+
+    /// Tries to resolve the pointer path for the `IL2CPP` class specified, even if a pointer path has been already found.
+    ///
+    /// Returns `true` if the pointer path has been resolved, `false` otherwise.
+    pub fn force_find(
+        &mut self,
+        process: &Process,
+        module: &Module,
+        image: &Image,
+        class_name: &str,
+        no_of_parents: u32,
+        fields: &[&str],
+    ) -> bool {
+        assert!(fields.len() == N);
+
+        // If this function runs, for whatever reason, the address of the static table must be invalidated
+        self.static_table = None;
+
+        // Finding the first class in the hierarchy from which we will build our pointer path
+        let Some(mut current_class) = image.get_class(process, module, class_name) else {
+            return false;
+        };
+
+        // Looping through all the needed parent classes, according to the number specified in the function argument
+        for _ in 0..no_of_parents {
+            let Some(parent_class) = current_class.get_parent(process, module) else {
+                return false;
+            };
+            current_class = parent_class;
+        }
+
+        let Some(static_table) = current_class.get_static_table(process, module) else {
+            return false;
+        };
+
+        let mut new_offsets = [0; N];
+
+        for i in 0..N {
+            // Try to parse the offset, passed as a string, as an actual hex or decimal value
+            let offset_from_string = {
+                let mut temp_val = None;
+
+                if fields[i].starts_with("0x") && fields[i].len() > 2 {
+                    if let Some(hex_val) = fields[i].get(2..fields[i].len()) {
+                        if let Ok(val) = u32::from_str_radix(hex_val, 16) {
+                            temp_val = Some(val)
+                        }
+                    }
+                } else if let Ok(val) = fields[i].parse::<u32>() {
+                    temp_val = Some(val)
+                }
+                temp_val
+            };
+
+            // Then we try finding the MonoClassField of interest, which is needed if we only provided the name of the field,
+            // and will be needed anyway when looking for the next offset.
+            let Some(target_field) = current_class.fields(process, module).find(|&field| {
+                if let Some(val) = offset_from_string {
+                    process
+                        .read::<u32>(field + module.offsets.monoclassfield_offset)
+                        .is_ok_and(|value| value == val)
+                } else {
+                    module
+                        .read_pointer(process, field + module.offsets.monoclassfield_name)
+                        .is_ok_and(|name_addr|
+                            process.read::<ArrayCString<128>>(name_addr)
+                            .is_ok_and(|name|
+                                name.matches(fields[i])))
+                }
+            }) else { return false };
+
+            new_offsets[i] = if let Some(val) = offset_from_string {
+                val
+            } else if let Ok(val) =
+                process.read::<u32>(target_field + module.offsets.monoclassfield_offset)
+            {
+                val
+            } else {
+                return false;
+            };
+
+            // In every iteration of the loop, except the last one, we then need to find the Class address for the next offset
+            if i != N - 1 {
+                let Ok(r#type) = module.read_pointer(process, target_field + module.size_of_ptr()) else {
+                    return false;
+                };
+                let Ok(type_definition) = module.read_pointer(process, r#type) else {
+                    return false;
+                };
+
+                let Ok(mut classes) = image.classes(process, module) else {
+                    return false;
+                };
+
+                let Some(new_class) = classes.find(|c| {
+                        module
+                            .read_pointer(
+                                process,
+                                c.class + module.offsets.monoclass_type_definition,
+                            )
+                            .is_ok_and(|val| val == type_definition)
+                    }
+                ) else {
+                    return false;
+                };
+
+                current_class = new_class;
+            }
+        }
+
+        self.is_64_bit = module.is_64_bit;
+        self.offsets = new_offsets;
+        self.static_table = Some(static_table);
+        true
+    }
+
+    /// Reads a value from the cached pointer path
+    pub fn read<T: CheckedBitPattern>(&self, process: &Process) -> Result<T, Error> {
+        let Some(mut address) = self.static_table else { return Err(Error {}) };
+        let depth = self.offsets.len();
+
+        if depth == 0 {
+            return process.read(address);
+        }
+
+        for offset in 0..depth {
+            if offset != depth - 1 {
+                address = match self.is_64_bit {
+                    true => process
+                        .read::<Address64>(address + self.offsets[offset])?
+                        .into(),
+                    false => process
+                        .read::<Address32>(address + self.offsets[offset])?
+                        .into(),
+                };
+            }
+        }
+        process.read(address + self.offsets[depth - 1])
+    }
+}
+
 struct Offsets {
     monoassembly_image: u8,
     monoassembly_aname: u8,
@@ -382,6 +558,7 @@ struct Offsets {
     monoimage_typecount: u8,
     monoimage_metadatahandle: u8,
     monoclass_name: u8,
+    monoclass_type_definition: u8,
     monoclass_fields: u8,
     monoclass_field_count: u16,
     monoclass_static_fields: u8,
@@ -407,6 +584,7 @@ impl Offsets {
                 monoimage_typecount: 0x1C,
                 monoimage_metadatahandle: 0x18, // MonoImage.typeStart
                 monoclass_name: 0x10,
+                monoclass_type_definition: 0x68,
                 monoclass_fields: 0x80,
                 monoclass_field_count: 0x114,
                 monoclass_static_fields: 0xB8,
@@ -422,6 +600,7 @@ impl Offsets {
                 monoimage_typecount: 0x1C,
                 monoimage_metadatahandle: 0x18, // MonoImage.typeStart
                 monoclass_name: 0x10,
+                monoclass_type_definition: 0x68,
                 monoclass_fields: 0x80,
                 monoclass_field_count: 0x11C,
                 monoclass_static_fields: 0xB8,
@@ -437,6 +616,7 @@ impl Offsets {
                 monoimage_typecount: 0x18,
                 monoimage_metadatahandle: 0x28,
                 monoclass_name: 0x10,
+                monoclass_type_definition: 0x68,
                 monoclass_fields: 0x80,
                 monoclass_field_count: 0x120,
                 monoclass_static_fields: 0xB8,

--- a/src/game_engine/unity/mono.rs
+++ b/src/game_engine/unity/mono.rs
@@ -498,7 +498,7 @@ impl<const N: usize> Pointer<N> {
         }
     }
 
-    /// Removes the internally stored address of the Mono clas    ///
+    /// Tries to resolve the internally stored address of the Mono class
     /// Returns `true` if the pointer path has been resolved, `false` otherwise.
     pub fn try_find(
         &mut self,

--- a/src/game_engine/unity/mono.rs
+++ b/src/game_engine/unity/mono.rs
@@ -527,10 +527,12 @@ impl<const N: usize> Pointer<N> {
         no_of_parents: u32,
         fields: &[&str],
     ) -> bool {
+        assert!(fields.len() == N);
+
         // If this function runs, for whatever reason, the address of the static table must be invalidated
         self.static_table = None;
 
-        // Finding the first class in thie hierarchy from which we will build our pointer path
+        // Finding the first class in the hierarchy from which we will build our pointer path
         let Some(mut current_class) = image.get_class(process, module, class_name) else {
             return false;
         };

--- a/src/game_engine/unity/mono.rs
+++ b/src/game_engine/unity/mono.rs
@@ -496,22 +496,15 @@ impl<const CAP: usize> Pointer<CAP> {
     pub fn new(class_name: &str, nr_of_parents: u8, fields: &[&str]) -> Self {
         assert!(!fields.is_empty() && fields.len() <= CAP);
 
-        let mut this_class_name = ArrayString::new();
-        this_class_name.push_str(class_name);
-
-        let mut this_fields = ArrayVec::new();
-        for &val in fields {
-            let mut string = ArrayString::new();
-            string.push_str(val);
-            this_fields.push(string);
-        }
-
         Self {
             static_table: OnceCell::new(),
             offsets: OnceCell::new(),
-            class_name: this_class_name,
+            class_name: ArrayString::from(class_name).unwrap_or_default(),
             nr_of_parents,
-            fields: this_fields,
+            fields: fields
+                .iter()
+                .map(|&val| ArrayString::from(val).unwrap_or_default())
+                .collect(),
         }
     }
 

--- a/src/game_engine/unity/mono.rs
+++ b/src/game_engine/unity/mono.rs
@@ -9,6 +9,7 @@ use core::iter;
 
 #[cfg(feature = "derive")]
 pub use asr_derive::MonoClass as Class;
+use bytemuck::CheckedBitPattern;
 
 /// Represents access to a Unity game that is using the standard Mono backend.
 pub struct Module {
@@ -477,6 +478,162 @@ impl Class {
     /// [`get_parent`](Self::get_parent) function.
     pub async fn wait_get_parent(&self, process: &Process, module: &Module) -> Class {
         retry(|| self.get_parent(process, module)).await
+    }
+}
+
+/// A Mono-specific implementation useful for automatic pointer path resolution
+pub struct Pointer<const N: usize> {
+    static_table: Option<Address>,
+    offsets: [u32; N],
+    is_64_bit: bool,
+}
+
+impl<const N: usize> Pointer<N> {
+    /// Creates a new instance of the Pointer struct
+    pub const fn new() -> Self {
+        Self {
+            static_table: None,
+            offsets: [0; N],
+            is_64_bit: false,
+        }
+    }
+
+    /// Removes the internally stored address of the Mono clas    ///
+    /// Returns `true` if the pointer path has been resolved, `false` otherwise.
+    pub fn try_find(
+        &mut self,
+        process: &Process,
+        module: &Module,
+        image: &Image,
+        class_name: &str,
+        no_of_parents: u32,
+        fields: &[&str],
+    ) -> bool {
+        match self.static_table {
+            None => self.force_find(process, module, image, class_name, no_of_parents, fields),
+            _ => true,
+        }
+    }
+
+    /// Tries to resolve the pointer path for the `Mono` class specified, even if a pointer path has been already found.
+    ///
+    /// Returns `true` if the pointer path has been resolved, `false` otherwise.
+    pub fn force_find(
+        &mut self,
+        process: &Process,
+        module: &Module,
+        image: &Image,
+        class_name: &str,
+        no_of_parents: u32,
+        fields: &[&str],
+    ) -> bool {
+        // If this function runs, for whatever reason, the address of the static table must be invalidated
+        self.static_table = None;
+
+        // Finding the first class in thie hierarchy from which we will build our pointer path
+        let Some(mut current_class) = image.get_class(process, module, class_name) else {
+            return false;
+        };
+
+        // Looping through all the needed parent classes, according to the number specified in the function argument
+        for _ in 0..no_of_parents {
+            let Some(parent_class) = current_class.get_parent(process, module) else {
+                return false;
+            };
+            current_class = parent_class;
+        }
+
+        let Some(static_table) = current_class.get_static_table(process, module) else {
+            return false;
+        };
+
+        let mut new_offsets = [0; N];
+
+        for i in 0..N {
+            // Try to parse the offset, passed as a string, as an actual hex or decimal value
+            let offset_from_string = {
+                let mut temp_val = None;
+
+                if fields[i].starts_with("0x") && fields[i].len() > 2 {
+                    if let Some(hex_val) = fields[i].get(2..fields[i].len()) {
+                        if let Ok(val) = u32::from_str_radix(hex_val, 16) {
+                            temp_val = Some(val)
+                        }
+                    }
+                } else if let Ok(val) = fields[i].parse::<u32>() {
+                    temp_val = Some(val)
+                }
+                temp_val
+            };
+
+            // Then we try finding the MonoClassField of interest, which is needed if we only provided the name of the field,
+            // and will be needed anyway when looking for the next offset.
+            let Some(target_field) = current_class.fields(process, module).find(|&field| {
+                if let Some(val) = offset_from_string {
+                    process
+                        .read::<u32>(field + module.offsets.monoclassfield_offset)
+                        .is_ok_and(|value| value == val)
+                } else {
+                    module
+                        .read_pointer(process, field + module.offsets.monoclassfield_name)
+                        .is_ok_and(|name_addr|
+                            process.read::<ArrayCString<128>>(name_addr)
+                            .is_ok_and(|name|
+                                name.matches(fields[i])))
+                }
+            }) else { return false };
+
+            new_offsets[i] = if let Some(val) = offset_from_string {
+                val
+            } else if let Ok(val) =
+                process.read::<u32>(target_field + module.offsets.monoclassfield_offset)
+            {
+                val
+            } else {
+                return false;
+            };
+
+            // In every iteration of the loop, except the last one, we then need to find the Class address for the next offset
+            if i != N - 1 {
+                let Ok(vtable) = module.read_pointer(process, target_field) else {
+                    return false;
+                };
+                let Ok(new_class) = module.read_pointer(process, vtable) else {
+                    return false;
+                };
+
+                current_class = Class { class: new_class };
+            }
+        }
+
+        self.is_64_bit = module.is_64_bit;
+        self.offsets = new_offsets;
+        self.static_table = Some(static_table);
+        true
+    }
+
+    /// Reads a value from the cached pointer path
+    pub fn read<T: CheckedBitPattern>(&self, process: &Process) -> Result<T, Error> {
+        let Some(mut address) = self.static_table else { return Err(Error {}) };
+        let depth = self.offsets.len();
+
+        if depth == 0 {
+            return process.read(address);
+        }
+
+        for offset in 0..depth {
+            if offset != depth - 1 {
+                address = match self.is_64_bit {
+                    true => process
+                        .read::<Address64>(address + self.offsets[offset])?
+                        .into(),
+                    false => process
+                        .read::<Address32>(address + self.offsets[offset])?
+                        .into(),
+                };
+            }
+        }
+        process.read(address + self.offsets[depth - 1])
     }
 }
 


### PR DESCRIPTION
This commit adds a new `Pointer` struct that allows for automatic resolution of pointer paths in Unity games, instead of relying to calling `get_class()`, `get_field()`, `get_parent()` or `get_static_table()` separatedly, simplifying the writing of autosplitters.

It is needed to specify the depth when creating a new instance. For example, `Pointer<2>` will dereference the path up to the 2nd offset.

The `try_find()` function is safe to leave in the main update loop, as it will immediately return if a pointer path has been found already. This serves as a workaround to solve issues with some Mono classes not getting instantiated when the game starts, which might block the execution of the autosplitter.

Example:

```rust
game.until_closes(async {
    let unity = &unity::mono::Module::wait_attach(&game, unity::mono::Version::V3).await;
    asr::print_message("Attached Unity module");

    let image = &unity.wait_get_default_image(&game).await;
    asr::print_message("Attached Assembly-CSharp.dll");

    let mut loaded_was_success = unity::mono::Pointer::<2>::new();

    loop {
        loaded_was_success.try_find(game, unity, image, "SystemManager", 1, &["_instance", "InitWasLoaded"]);

        if let Ok(val) = loaded_was_success.read::<u8>(game) {
            asr::print_limited::<8>(&"Success!");
        }

        next_tick().await;
    }
})
.await;

```