### PR TITLE
Bugfixing

### DIFF
--- a/src/game_engine/unity/scene.rs
+++ b/src/game_engine/unity/scene.rs
@@ -290,7 +290,7 @@ impl GameObject {
             })
         };
 
-        Ok((0..number_of_components).filter_map(move |m| {
+        Ok((1..number_of_components).filter_map(move |m| {
             scene_manager
                 .read_pointer(process, components[m] + scene_manager.offsets.klass)
                 .ok()


### PR DESCRIPTION
The first entry in every `GameObject` is a `Transform`, so it can be skipped over when looking for a class object. (Thanks Micrologist for the tip)

Considering how slow this code is, every possible optimization, even little, should be welcome.