### PR TITLE
[Unity] Improved performance of the `root_game_objects` function

### DIFF
--- a/src/game_engine/unity/scene.rs
+++ b/src/game_engine/unity/scene.rs
@@ -4,7 +4,7 @@
 // https://gist.githubusercontent.com/just-ero/92457b51baf85bd1e5b8c87de8c9835e/raw/8aa3e6b8da01fd03ff2ff0c03cbd018e522ef988/UnityScene.hpp
 // Offsets and logic for the GameObject functions taken from https://github.com/Micrologist/UnityInstanceDumper
 
-use core::{array, mem::MaybeUninit};
+use core::{array, iter, mem::MaybeUninit};
 
 use crate::{
     file_format::pe, future::retry, signature::Signature, string::ArrayCString, Address, Address32,


### PR DESCRIPTION
This refactor of the `root_game_objects` doubles its performance by avoiding looping through the `List` of `GameObjects` twice.

The previous implementation used to loop once to count the number of elements, only for looping again a second time to get the memory pointers. This is effectively unneded as the number of objects can be inferred by the number of elements in the iterator, and wastes computing time to winapi calls.

This also helps improving performance while looping for objects through the linked list of `Transform`s in a Unity scene, a very cpu intensive process.