### PR TITLE
[BUGFIX] Added new sigscan for DuckStation (PS1 emu)

### DIFF
--- a/src/emulator/ps1/duckstation.rs
+++ b/src/emulator/ps1/duckstation.rs
@@ -1,4 +1,4 @@
-use crate::{signature::Signature, Address, Address64, Process};
+use crate::{file_format::pe, signature::Signature, Address, Address64, Process};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct State {
@@ -7,26 +7,28 @@ pub struct State {
 
 impl State {
     pub fn find_ram(&mut self, game: &Process) -> Option<Address> {
-        const SIG: Signature<12> = Signature::new("48 89 ?? ?? ?? ?? ?? ?? FF FF 1F 00");
-        const SIG_OLD: Signature<8> = Signature::new("48 89 0D ?? ?? ?? ?? B8");
+        const SIG: Signature<8> = Signature::new("48 89 0D ?? ?? ?? ?? B8");
 
         let main_module_range = super::PROCESS_NAMES
             .iter()
             .filter(|(_, state)| matches!(state, super::State::Duckstation(_)))
             .find_map(|(name, _)| game.get_module_range(name).ok())?;
 
-        let addr: Address = {
-            if let Some(ptr) = SIG.scan_process_range(game, main_module_range) {
-                ptr
-            } else {
-                SIG_OLD.scan_process_range(game, main_module_range)?
-            }
-        } + 3;
+        // Recent Duckstation releases include a debug symbol that can be used to easily retrieve the address of the emulated RAM
+        // Info: https://github.com/stenzek/duckstation/commit/c98e0bd0969abdd82589bfc565aea52119fd0f19
+        if let Some(debug_symbol) = pe::symbols(game, main_module_range.0).find(|symbol| {
+            symbol
+                .get_name::<4>(game)
+                .is_ok_and(|name| name.matches(b"RAM"))
+        }) {
+            self.addr = debug_symbol.address;
+        } else {
+            // For older versions of Duckstation, we fall back to regular sigscanning
+            let addr = SIG.scan_process_range(game, main_module_range)? + 3;
+            self.addr = addr + 0x4 + game.read::<i32>(addr).ok()?;
+        }
 
-        self.addr = addr + 0x4 + game.read::<i32>(addr).ok()?;
-
-        let ram = game.read::<Address64>(self.addr).ok()?;
-        Some(ram.into())
+        Some(game.read::<Address64>(self.addr).ok()?.into())
     }
 
     pub fn keep_alive(&self, game: &Process, wram_base: &mut Option<Address>) -> bool {


### PR DESCRIPTION
Due to a recent change in the source code (https://github.com/stenzek/duckstation/commit/56fc207af69601b702e4965494103f553909d3b1), the sigscan that was currently used for DuckStation is no longer valid.

A new sigscan has been added to support the latest release of said emulator.

Unfortunately, due to the nature of the crate, existing autosplitters will need to be recompiled in order to support these recent releases of the emulator.