### PR TITLE
Added the ability to iterate over exported symbols in a given pe module

### DIFF
--- a/src/file_format/pe.rs
+++ b/src/file_format/pe.rs
@@ -295,7 +295,7 @@ impl Symbol {
 pub fn symbols(
     process: &Process,
     module_address: impl Into<Address>,
-) -> impl DoubleEndedIterator<Item = Symbol<CAP>> + '_ {
+) -> impl DoubleEndedIterator<Item = Symbol> + '_ {
     let address: Address = module_address.into();
     let dos_header = process.read::<DOSHeader>(address);
 

--- a/src/file_format/pe.rs
+++ b/src/file_format/pe.rs
@@ -292,7 +292,7 @@ impl Symbol {
 
 /// Recovers and iterates over the exported symbols for a given module.
 /// Returns an empty iterator if no symbols are exported into the current module.
-pub fn symbols<const CAP: usize>(
+pub fn symbols(
     process: &Process,
     module_address: impl Into<Address>,
 ) -> impl DoubleEndedIterator<Item = Symbol<CAP>> + '_ {

--- a/src/file_format/pe.rs
+++ b/src/file_format/pe.rs
@@ -4,7 +4,7 @@ use core::{fmt, mem};
 
 use bytemuck::{Pod, Zeroable};
 
-use crate::{string::ArrayCString, Address, FromEndian, Process};
+use crate::{string::ArrayCString, Address, FromEndian, Process, Error};
 
 // Reference:
 // https://learn.microsoft.com/en-us/windows/win32/debug/pe-format


### PR DESCRIPTION
Some processes do export useful symbols that can be used to recover memory addresses or other useful values. The newly added `symbols()` function allows to iterate over them in order to recover, if needed, the addresses of interest.

For example, Duckstation (a PS1 emulator) exports the address of the emulated RAM as a symbol, so it can be easily recovered.

Esample:

```rust
let pointer: Option<Symbol> = pe::symbols(&process, main_module).find(|symbol| {
    symbol
        .get_name::<5>(&process)
        .is_ok_and(|name| name.matches(b"RAM"))
});

let address: Address = pointer.unwrap().address;
```