### PR TITLE
[Unity] Various edits in the Unity code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ time = { version = "0.3.5", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
 libm = { version = "0.2.7", optional = true }
-wasi = { version = "0.11.0", default-features = false }
+wasi = { version = "0.11.0+wasi-snapshot-preview1", default-features = false }
 
 [features]
 alloc = []

--- a/src/emulator/gba/mod.rs
+++ b/src/emulator/gba/mod.rs
@@ -114,13 +114,8 @@ impl Emulator {
 
         self.state.set(state);
 
-        if success {
-            self.ram_base.set(ram_base);
-            true
-        } else {
-            self.ram_base.set(None);
-            false
-        }
+        self.ram_base.set(if success { ram_base } else { None });
+        success
     }
 
     /// Reads any value from the emulated RAM.

--- a/src/emulator/sms/retroarch.rs
+++ b/src/emulator/sms/retroarch.rs
@@ -1,4 +1,6 @@
-use crate::{file_format::pe, signature::Signature, Address, Address32, Address64, Process};
+use crate::{
+    file_format::pe, signature::Signature, Address, Address32, Address64, PointerSize, Process,
+};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct State {
@@ -94,8 +96,9 @@ impl State {
                 .read::<u8>(ptr + 13 + 0x4 + game.read::<i32>(ptr + 13).ok()? + 3)
                 .ok()?;
             let addr = game
-                .read_pointer_path64::<Address64>(
+                .read_pointer_path::<Address64>(
                     ptr + 0x4 + game.read::<i32>(ptr).ok()?,
+                    PointerSize::Bit64,
                     &[0x0, 0x0, offset as _],
                 )
                 .ok()?;
@@ -111,7 +114,11 @@ impl State {
                 .read::<u8>(ptr + 12 + 0x4 + game.read::<i32>(ptr + 12).ok()? + 2)
                 .ok()?;
             let addr = game
-                .read_pointer_path32::<Address32>(ptr, &[0x0, 0x0, 0x0, offset as _])
+                .read_pointer_path::<Address32>(
+                    ptr,
+                    PointerSize::Bit32,
+                    &[0x0, 0x0, 0x0, offset as _],
+                )
                 .ok()?;
             if addr.is_null() {
                 return None;

--- a/src/file_format/elf.rs
+++ b/src/file_format/elf.rs
@@ -8,7 +8,7 @@ use core::{
 
 use bytemuck::{Pod, Zeroable};
 
-use crate::{string::ArrayCString, Address, Endian, Error, FromEndian, Process};
+use crate::{string::ArrayCString, Address, Endian, Error, FromEndian, PointerSize, Process};
 
 // Based on:
 // https://refspecs.linuxfoundation.org/elf/elf.pdf
@@ -98,6 +98,15 @@ impl Bitness {
     /// Checks whether the bitness is 64-bit.
     pub fn is_64(self) -> bool {
         self == Self::BITNESS_64
+    }
+
+    /// Returns the pointer size for the given bitness.
+    pub const fn pointer_size(self) -> Option<PointerSize> {
+        Some(match self {
+            Self::BITNESS_64 => PointerSize::Bit64,
+            Self::BITNESS_32 => PointerSize::Bit32,
+            _ => return None,
+        })
     }
 }
 

--- a/src/file_format/pe.rs
+++ b/src/file_format/pe.rs
@@ -4,7 +4,7 @@ use core::{fmt, mem};
 
 use bytemuck::{Pod, Zeroable};
 
-use crate::{string::ArrayCString, Address, Error, FromEndian, Process};
+use crate::{string::ArrayCString, Address, Error, FromEndian, PointerSize, Process};
 
 // Reference:
 // https://learn.microsoft.com/en-us/windows/win32/debug/pe-format
@@ -236,6 +236,16 @@ impl MachineType {
     pub const THUMB: Self = Self(0x1c2);
     /// MIPS little-endian WCE v2
     pub const WCEMIPSV2: Self = Self(0x169);
+
+    /// Returns the pointer size for the given machine type. Only the most
+    /// common machine types are supported.
+    pub const fn pointer_size(self) -> Option<PointerSize> {
+        Some(match self {
+            Self::AMD64 | Self::ARM64 | Self::IA64 => PointerSize::Bit64,
+            Self::I386 | Self::ARM => PointerSize::Bit32,
+            _ => return None,
+        })
+    }
 }
 
 /// Reads the size of the image of a module (`exe` or `dll`) from the given

--- a/src/game_engine/unity/il2cpp.rs
+++ b/src/game_engine/unity/il2cpp.rs
@@ -623,7 +623,6 @@ struct Offsets {
     monoimage_typecount: u8,
     monoimage_metadatahandle: u8,
     monoclass_name: u8,
-    monoclass_type_definition: u8,
     monoclass_fields: u8,
     monoclass_field_count: u16,
     monoclass_static_fields: u8,
@@ -649,7 +648,6 @@ impl Offsets {
                 monoimage_typecount: 0x1C,
                 monoimage_metadatahandle: 0x18, // MonoImage.typeStart
                 monoclass_name: 0x10,
-                monoclass_type_definition: 0x68,
                 monoclass_fields: 0x80,
                 monoclass_field_count: 0x114,
                 monoclass_static_fields: 0xB8,
@@ -665,7 +663,6 @@ impl Offsets {
                 monoimage_typecount: 0x1C,
                 monoimage_metadatahandle: 0x18, // MonoImage.typeStart
                 monoclass_name: 0x10,
-                monoclass_type_definition: 0x68,
                 monoclass_fields: 0x80,
                 monoclass_field_count: 0x11C,
                 monoclass_static_fields: 0xB8,
@@ -681,7 +678,6 @@ impl Offsets {
                 monoimage_typecount: 0x18,
                 monoimage_metadatahandle: 0x28,
                 monoclass_name: 0x10,
-                monoclass_type_definition: 0x68,
                 monoclass_fields: 0x80,
                 monoclass_field_count: 0x120,
                 monoclass_static_fields: 0xB8,

--- a/src/game_engine/unity/il2cpp.rs
+++ b/src/game_engine/unity/il2cpp.rs
@@ -1,6 +1,6 @@
 //! Support for attaching to Unity games that are using the IL2CPP backend.
 
-use core::cell::OnceCell;
+use core::cell::RefCell;
 
 use crate::{
     deep_pointer::{DeepPointer, DerefType},
@@ -10,7 +10,7 @@ use crate::{
     string::ArrayCString,
     Address, Address32, Address64, Error, Process,
 };
-use arrayvec::{ArrayString, ArrayVec};
+
 #[cfg(feature = "derive")]
 pub use asr_derive::Il2cppClass as Class;
 use bytemuck::CheckedBitPattern;
@@ -220,6 +220,7 @@ impl Module {
     }
 }
 
+#[derive(Copy, Clone)]
 struct Assembly {
     assembly: Address,
 }
@@ -249,6 +250,7 @@ impl Assembly {
 
 /// An image is a .NET DLL that is loaded by the game. The `Assembly-CSharp`
 /// image is the main game assembly, and contains all the game logic.
+#[derive(Copy, Clone)]
 pub struct Image {
     image: Address,
 }
@@ -320,7 +322,8 @@ impl Image {
     }
 }
 
-/// A .NET class that is part of an [`Image`].
+/// A .NET class that is part of an [`Image`](Image).
+#[derive(Copy, Clone)]
 pub struct Class {
     class: Address,
 }
@@ -444,6 +447,7 @@ impl Class {
     }
 }
 
+#[derive(Copy, Clone)]
 struct Field {
     field: Address,
 }
@@ -465,116 +469,156 @@ impl Field {
 }
 
 /// An IL2CPP-specific implementation for automatic pointer path resolution
+#[derive(Clone)]
 pub struct UnityPointer<const CAP: usize> {
-    deep_pointer: OnceCell<DeepPointer<CAP>>,
-    class_name: ArrayString<CSTR>,
-    nr_of_parents: u8,
-    fields: ArrayVec<ArrayString<CSTR>, CAP>,
+    cache: RefCell<UnityPointerCache<CAP>>,
+    class_name: &'static str,
+    nr_of_parents: usize,
+    fields: [&'static str; CAP],
+    depth: usize,
+}
+
+#[derive(Clone)]
+struct UnityPointerCache<const CAP: usize> {
+    base_address: Address,
+    offsets: [u64; CAP],
+    resolved_offsets: usize,
+    current_instance_pointer: Option<Address>,
+    starting_class: Option<Class>,
 }
 
 impl<const CAP: usize> UnityPointer<CAP> {
     /// Creates a new instance of the Pointer struct
     ///
-    /// `CAP` must be higher or equal to the number of offsets defined in `fields`.
+    /// `CAP` should be higher or equal to the number of offsets defined in `fields`.
     ///
-    /// If `CAP` is set to a value lower than the number of the offsets to be dereferenced, this function will ***Panic***
-    pub fn new(class_name: &str, nr_of_parents: u8, fields: &[&str]) -> Self {
-        assert!(!fields.is_empty() && fields.len() <= CAP);
+    /// If a higher number of offsets is provided, the pointer path will be truncated
+    /// according to the value of `CAP`.
+    pub fn new(class_name: &'static str, nr_of_parents: usize, fields: &[&'static str]) -> Self {
+        let this_fields = {
+            let mut val = [""; CAP];
+            for (i, &item) in fields.iter().enumerate() {
+                if i < CAP {
+                    val[i] = item;
+                }
+            }
+            val
+        };
+
+        let len = fields.len();
+        let depth = if len > CAP { CAP } else { len };
+
+        let cache = RefCell::new(UnityPointerCache {
+            base_address: Address::default(),
+            offsets: [u64::default(); CAP],
+            current_instance_pointer: None,
+            starting_class: None,
+            resolved_offsets: usize::default(),
+        });
 
         Self {
-            deep_pointer: OnceCell::new(),
-            class_name: ArrayString::from(class_name).unwrap_or_default(),
+            cache,
+            class_name,
             nr_of_parents,
-            fields: fields
-                .iter()
-                .map(|&val| ArrayString::from(val).unwrap_or_default())
-                .collect(),
+            fields: this_fields,
+            depth,
         }
     }
 
     /// Tries to resolve the pointer path for the `IL2CPP` class specified
     fn find_offsets(&self, process: &Process, module: &Module, image: &Image) -> Result<(), Error> {
+        let mut cache = self.cache.borrow_mut();
+
         // If the pointer path has already been found, there's no need to continue
-        if self.deep_pointer.get().is_some() {
+        if cache.resolved_offsets == self.depth {
             return Ok(());
         }
 
-        let mut current_class = image
-            .get_class(process, module, &self.class_name)
-            .ok_or(Error {})?;
-
-        for _ in 0..self.nr_of_parents {
-            current_class = current_class.get_parent(process, module).ok_or(Error {})?;
-        }
-
-        let static_table = current_class
-            .get_static_table(process, module)
-            .ok_or(Error {})?;
-        let mut current_instance = static_table;
-        let mut offsets: ArrayVec<u64, CAP> = ArrayVec::new();
-
-        for (i, &field_name) in self.fields.iter().enumerate() {
-            // Try to parse the offset, passed as a string, as an actual hex or decimal value
-            let offset_from_string = {
-                let mut temp_val = None;
-
-                if field_name.starts_with("0x") && field_name.len() > 2 {
-                    if let Some(hex_val) = field_name.get(2..field_name.len()) {
-                        if let Ok(val) = u32::from_str_radix(hex_val, 16) {
-                            temp_val = Some(val)
-                        }
-                    }
-                } else if let Ok(val) = field_name.parse::<u32>() {
-                    temp_val = Some(val)
-                }
-                temp_val
-            };
-
-            // Then we try finding the MonoClassField of interest, which is needed if we only provided the name of the field,
-            // and will be needed anyway when looking for the next offset.
-            let target_field = current_class
-                .fields(process, module)
-                .find(|field| {
-                    if let Some(val) = offset_from_string {
-                        field
-                            .get_offset(process, module)
-                            .is_some_and(|offset| offset == val)
-                    } else {
-                        field
-                            .get_name::<CSTR>(process, module)
-                            .is_ok_and(|name| name.matches(field_name.as_ref()))
-                    }
-                })
+        // Logic: the starting class can be recovered with the get_class() function,
+        // and parent class can be recovered if needed. However, this is a VERY
+        // intensive process because it involves looping through all the main classes
+        // in the game. For this reason, once the class is found, we want to store it
+        // into the cache, where it can be recovered if this function need to be run again
+        // (for example if a previous attempt at pointer path resolution failed)
+        let starting_class = if let Some(starting_class) = cache.starting_class {
+            starting_class
+        } else {
+            let mut current_class = image
+                .get_class(process, module, self.class_name)
                 .ok_or(Error {})?;
 
-            let current_offset = match offset_from_string {
-                Some(val) => val,
-                _ => target_field.get_offset(process, module).ok_or(Error {})?,
-            } as _;
-
-            offsets.push(current_offset);
-
-            // In every iteration of the loop, except the last one, we then need to find the Class address for the next offset
-            if i != self.fields.len() - 1 {
-                current_instance =
-                    module.read_pointer(process, current_instance + current_offset)?;
-
-                current_class = Class {
-                    class: module.read_pointer(process, current_instance)?,
-                };
+            for _ in 0..self.nr_of_parents {
+                current_class = current_class.get_parent(process, module).ok_or(Error {})?;
             }
+
+            cache.starting_class = Some(current_class);
+            current_class
+        };
+
+        // Recovering the address of the static table is not very CPU intensive,
+        // but it might be worth caching it as well
+        if cache.base_address.is_null() {
+            let s_table = starting_class
+                .get_static_table(process, module)
+                .ok_or(Error {})?;
+            cache.base_address = s_table;
+        };
+
+        // As we need to be able to find instances in a more reliable way,
+        // instead of the Class itself, we need the address pointing to an
+        // instance of that Class. If the cache is empty, we start from the
+        // pointer to the static table of the first class.
+        let mut current_instance_pointer = if let Some(val) = cache.current_instance_pointer {
+            val
+        } else {
+            starting_class.class + module.offsets.monoclass_static_fields
+        };
+
+        // We keep track of the already resolved offsets in order to skip resolving them again
+        for i in cache.resolved_offsets..self.depth {
+            let class_instance = module.read_pointer(process, current_instance_pointer)?;
+
+            // If either of those two addresses is null, something went wrong during the pointer path resolution
+            if class_instance.is_null() {
+                return Err(Error {});
+            }
+
+            // Try to parse the offset, passed as a string, as an actual hex or decimal value
+            let offset_from_string = super::value_from_string(self.fields[i]);
+
+            let current_offset = if let Some(offset) = offset_from_string {
+                offset as u64
+            } else {
+                let current_class = if i == 0 {
+                    starting_class
+                } else {
+                    let class = module.read_pointer(process, class_instance)?;
+                    if class.is_null() {
+                        return Err(Error {});
+                    } else {
+                        Class { class }
+                    }
+                };
+
+                current_class
+                    .fields(process, module)
+                    .find(|field| {
+                        field
+                            .get_name::<CSTR>(process, module)
+                            .is_ok_and(|name| name.matches(self.fields[i]))
+                    })
+                    .ok_or(Error {})?
+                    .get_offset(process, module)
+                    .ok_or(Error {})? as u64
+            };
+
+            cache.offsets[i] = current_offset;
+
+            current_instance_pointer = class_instance + current_offset;
+            cache.current_instance_pointer = Some(current_instance_pointer);
+            cache.resolved_offsets += 1;
         }
 
-        let pointer = DeepPointer::new(
-            static_table,
-            if module.is_64_bit {
-                DerefType::Bit64
-            } else {
-                DerefType::Bit32
-            },
-            &offsets,
-        );
-        let _ = self.deep_pointer.set(pointer);
         Ok(())
     }
 
@@ -586,10 +630,16 @@ impl<const CAP: usize> UnityPointer<CAP> {
         image: &Image,
     ) -> Result<Address, Error> {
         self.find_offsets(process, module, image)?;
-        self.deep_pointer
-            .get()
-            .ok_or(Error {})?
-            .deref_offsets(process)
+        let cache = self.cache.borrow();
+        let mut address = cache.base_address;
+        let (&last, path) = cache.offsets[..self.depth].split_last().ok_or(Error {})?;
+        for &offset in path {
+            address = match module.is_64_bit {
+                true => process.read::<Address64>(address + offset)?.into(),
+                false => process.read::<Address32>(address + offset)?.into(),
+            };
+        }
+        Ok(address + last)
     }
 
     /// Dereferences the pointer path, returning the value stored at the final memory address
@@ -600,11 +650,11 @@ impl<const CAP: usize> UnityPointer<CAP> {
         image: &Image,
     ) -> Result<T, Error> {
         self.find_offsets(process, module, image)?;
-        self.deep_pointer.get().ok_or(Error {})?.deref(process)
+        process.read(self.deref_offsets(process, module, image)?)
     }
 
-    /// Recovers the `DeepPointer` struct contained inside this `UnityPointer`,
-    /// if the offsets have been found
+    /// Generates a `DeepPointer` struct based on the offsets
+    /// recovered from this `UnityPointer`.
     pub fn get_deep_pointer(
         &self,
         process: &Process,
@@ -612,7 +662,16 @@ impl<const CAP: usize> UnityPointer<CAP> {
         image: &Image,
     ) -> Option<DeepPointer<CAP>> {
         self.find_offsets(process, module, image).ok()?;
-        self.deep_pointer.get().cloned()
+        let cache = self.cache.borrow();
+        Some(DeepPointer::<CAP>::new(
+            cache.base_address,
+            if module.is_64_bit {
+                DerefType::Bit64
+            } else {
+                DerefType::Bit32
+            },
+            &cache.offsets[..self.depth],
+        ))
     }
 }
 

--- a/src/game_engine/unity/mod.rs
+++ b/src/game_engine/unity/mod.rs
@@ -90,16 +90,9 @@ mod scene;
 pub use self::scene::*;
 
 fn value_from_string(value: &str) -> Option<u32> {
-    let mut temp_val = None;
-
-    if value.starts_with("0x") && value.len() > 2 {
-        if let Some(hex_val) = value.get(2..value.len()) {
-            if let Ok(val) = u32::from_str_radix(hex_val, 16) {
-                temp_val = Some(val)
-            }
-        }
-    } else if let Ok(val) = value.parse::<u32>() {
-        temp_val = Some(val)
+    if let Some(rem) = value.strip_prefix("0x") {
+        u32::from_str_radix(rem, 16).ok()
+    } else {
+        value.parse().ok()
     }
-    temp_val
 }

--- a/src/game_engine/unity/mod.rs
+++ b/src/game_engine/unity/mod.rs
@@ -88,3 +88,18 @@ pub mod mono;
 
 mod scene;
 pub use self::scene::*;
+
+fn value_from_string(value: &str) -> Option<u32> {
+    let mut temp_val = None;
+
+    if value.starts_with("0x") && value.len() > 2 {
+        if let Some(hex_val) = value.get(2..value.len()) {
+            if let Ok(val) = u32::from_str_radix(hex_val, 16) {
+                temp_val = Some(val)
+            }
+        }
+    } else if let Ok(val) = value.parse::<u32>() {
+        temp_val = Some(val)
+    }
+    temp_val
+}

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -2,3 +2,16 @@ mod address;
 mod endian;
 
 pub use self::{address::*, endian::*};
+
+/// Pointer size represents the width (in bytes) of memory addresses used
+/// in a certain process.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[repr(u8)]
+pub enum PointerSize {
+    /// A 16-bit (2 byte wide) pointer size
+    Bit16 = 0x2,
+    /// A 32-bit (4 byte wide) pointer size
+    Bit32 = 0x4,
+    /// A 64-bit (8 byte wide) pointer size
+    Bit64 = 0x8,
+}

--- a/src/runtime/settings/gui.rs
+++ b/src/runtime/settings/gui.rs
@@ -55,17 +55,17 @@ pub fn add_title(key: &str, description: &str, heading_level: u32) {
 /// of settings. The description is what's shown to the user. The key of the
 /// default option to show needs to be specified.
 #[inline]
-pub fn add_choice(key: &str, description: &str, default_item_key: &str) {
+pub fn add_choice(key: &str, description: &str, default_option_key: &str) {
     // SAFETY: We provide valid pointers and lengths to key, description and
-    // default_item_key. They are also guaranteed to be valid UTF-8 strings.
+    // default_option_key. They are also guaranteed to be valid UTF-8 strings.
     unsafe {
         sys::user_settings_add_choice(
             key.as_ptr(),
             key.len(),
             description.as_ptr(),
             description.len(),
-            default_item_key.as_ptr(),
-            default_item_key.len(),
+            default_option_key.as_ptr(),
+            default_option_key.len(),
         )
     }
 }


### PR DESCRIPTION
This fixes automatic pointer path resolution for Unity games by adding 2 features:

1. caching of resolved offsets
   If the code is dealing with Classes that didn't run their cctor, automatic pointer path resolution fails. However, caching the offsets already resolved allows the script to skip over them instead of looking for them again. This greatly improves performance, as some functions, especially the get_class() one, are very intensive and slow, requiring hundredths of memory reads in some games and potentially stalling the execution of the autosplitter

2. looking for child classes through their vtable
  This also fixes automatic pointer path resolution when traversing arrays or standard C# structures the previous implementation of this function was failing on.

Together with its companion PR https://github.com/LiveSplit/asr/pull/69 , this should fix most if not all the outstanding bugs there were left and I could identify so far with this engine.


A couple of additional commits have also been added in roder to have `Copy` on the `DeepPointer` struct, as well as adding a `read_pointer()` function inside `Process`.