### PR TITLE
Spport querying setting values as `ArrayString`

### DIFF
--- a/src/runtime/sys.rs
+++ b/src/runtime/sys.rs
@@ -304,7 +304,6 @@ extern "C" {
     /// UTF-8 and is not nul-terminated. No matter what happens, you still
     /// retain ownership of the setting value, which means you still need to
     /// free it.
-    #[cfg(feature = "alloc")]
     pub fn setting_value_get_string(
         value: SettingValue,
         buf_ptr: *mut u8,


### PR DESCRIPTION
This allows you to query the value of a setting value as an `ArrayString`, which is a string that is backed by an array. This has the advantage that it doesn't not need an allocator, but you need to specify a maximum length.