### PR TITLE
Add support for Settings Lists

### DIFF
--- a/src/emulator/gba/mednafen.rs
+++ b/src/emulator/gba/mednafen.rs
@@ -33,9 +33,9 @@ impl State {
                 addr
             };
 
-            
             self.cached_iwram_pointer = {
-                const SIG2: Signature<13> = Signature::new("48 8B 05 ?? ?? ?? ?? 81 E1 FF 7F 00 00");
+                const SIG2: Signature<13> =
+                    Signature::new("48 8B 05 ?? ?? ?? ?? 81 E1 FF 7F 00 00");
                 let ptr: Address = SIG2.scan_process_range(game, main_module_range)? + 3;
                 let mut addr: Address = ptr + 0x4 + game.read::<i32>(ptr).ok()?;
 
@@ -45,8 +45,8 @@ impl State {
                         return None;
                     }
                 }
-                
-                addr           
+
+                addr
             };
 
             let ewram = game.read::<Address64>(self.cached_ewram_pointer).ok()?;
@@ -60,13 +60,12 @@ impl State {
                 game.read::<Address32>(ptr + 1).ok()?.into()
             };
 
-
             self.cached_iwram_pointer = {
                 const SIG2: Signature<11> = Signature::new("A1 ?? ?? ?? ?? 81 ?? FF 7F 00 00");
                 let ptr = SIG2.scan_process_range(game, main_module_range)?;
                 game.read::<Address32>(ptr + 1).ok()?.into()
             };
-    
+
             let ewram = game.read::<Address32>(self.cached_ewram_pointer).ok()?;
             let iwram = game.read::<Address32>(self.cached_iwram_pointer).ok()?;
 

--- a/src/emulator/gba/mod.rs
+++ b/src/emulator/gba/mod.rs
@@ -3,12 +3,12 @@
 use crate::{Address, Error, Process};
 use bytemuck::CheckedBitPattern;
 
+mod emuhawk;
+mod mednafen;
 mod mgba;
 mod nocashgba;
 mod retroarch;
 mod vba;
-mod emuhawk;
-mod mednafen;
 
 /// A Nintendo Gameboy Advance emulator that the auto splitter is attached to.
 pub struct Emulator {
@@ -84,7 +84,7 @@ impl Emulator {
             false => {
                 self.ram_base = None;
                 false
-            },
+            }
         }
     }
 

--- a/src/emulator/gba/vba.rs
+++ b/src/emulator/gba/vba.rs
@@ -48,24 +48,24 @@ impl State {
                         return None;
                     }
                 }
-                
-                addr           
+
+                addr
             };
 
-
             self.is_emulating = {
-                const SIG_RUNNING: Signature<19> = Signature::new("83 3D ?? ?? ?? ?? 00 74 ?? 80 3D ?? ?? ?? ?? 00 75 ?? 66");
-                const SIG_RUNNING2: Signature<16> = Signature::new("48 8B 15 ?? ?? ?? ?? 31 C0 8B 12 85 D2 74 ?? 48");
+                const SIG_RUNNING: Signature<19> =
+                    Signature::new("83 3D ?? ?? ?? ?? 00 74 ?? 80 3D ?? ?? ?? ?? 00 75 ?? 66");
+                const SIG_RUNNING2: Signature<16> =
+                    Signature::new("48 8B 15 ?? ?? ?? ?? 31 C0 8B 12 85 D2 74 ?? 48");
 
                 if let Some(ptr) = SIG_RUNNING.scan_process_range(game, main_module_range) {
                     let ptr = ptr + 2;
-                    ptr + 0x4 + game.read::<i32>(ptr).ok()? + 0x1 
+                    ptr + 0x4 + game.read::<i32>(ptr).ok()? + 0x1
                 } else {
                     let ptr = SIG_RUNNING2.scan_process_range(game, main_module_range)? + 3;
                     let ptr = ptr + 0x4 + game.read::<i32>(ptr).ok()?;
                     game.read::<Address64>(ptr).ok()?.into()
                 }
-
             };
 
             let ewram = game.read::<Address64>(self.cached_ewram_pointer).ok()?;
@@ -75,7 +75,7 @@ impl State {
         } else {
             const SIG: Signature<11> = Signature::new("A1 ?? ?? ?? ?? 81 ?? FF FF 03 00");
             const SIG_OLD: Signature<12> = Signature::new("81 E6 FF FF 03 00 8B 15 ?? ?? ?? ??");
-            
+
             if let Some(ptr) = SIG.scan_process_range(game, main_module_range) {
                 self.cached_ewram_pointer = game.read::<Address32>(ptr + 1).ok()?.into();
                 self.cached_iwram_pointer = {
@@ -83,17 +83,20 @@ impl State {
                     let ptr = SIG2.scan_process_range(game, main_module_range)?;
                     game.read::<Address32>(ptr + 1).ok()?.into()
                 };
-                
-                self.is_emulating = {
-                    const SIG: Signature<19> = Signature::new("83 3D ?? ?? ?? ?? 00 74 ?? 80 3D ?? ?? ?? ?? 00 75 ?? 66");
-                    const SIG_OLD: Signature<13> = Signature::new("8B 15 ?? ?? ?? ?? 31 C0 85 D2 74 ?? 0F");
 
-                    let ptr = SIG.scan_process_range(game, main_module_range)
+                self.is_emulating = {
+                    const SIG: Signature<19> =
+                        Signature::new("83 3D ?? ?? ?? ?? 00 74 ?? 80 3D ?? ?? ?? ?? 00 75 ?? 66");
+                    const SIG_OLD: Signature<13> =
+                        Signature::new("8B 15 ?? ?? ?? ?? 31 C0 85 D2 74 ?? 0F");
+
+                    let ptr = SIG
+                        .scan_process_range(game, main_module_range)
                         .or_else(|| SIG_OLD.scan_process_range(game, main_module_range))?;
 
                     game.read::<Address32>(ptr + 2).ok()?.into()
                 };
-        
+
                 let ewram = game.read::<Address32>(self.cached_ewram_pointer).ok()?;
                 let iwram = game.read::<Address32>(self.cached_iwram_pointer).ok()?;
 
@@ -104,11 +107,12 @@ impl State {
                 self.cached_iwram_pointer = self.cached_ewram_pointer.add_signed(0x4);
 
                 self.is_emulating = {
-                    const SIG_RUNNING: Signature<11> = Signature::new("8B 0D ?? ?? ?? ?? 85 C9 74 ?? 8A");
+                    const SIG_RUNNING: Signature<11> =
+                        Signature::new("8B 0D ?? ?? ?? ?? 85 C9 74 ?? 8A");
                     let ptr = SIG_RUNNING.scan_process_range(game, main_module_range)? + 2;
                     game.read::<Address32>(ptr).ok()?.into()
                 };
-    
+
                 let ewram = game.read::<Address32>(self.cached_ewram_pointer).ok()?;
                 let iwram = game.read::<Address32>(self.cached_iwram_pointer).ok()?;
 

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -11,7 +11,6 @@ use super::{sys, Error, MemoryRange};
 pub use super::sys::ProcessId;
 
 /// A process that the auto splitter is attached to.
-#[derive(Debug)]
 #[repr(transparent)]
 pub struct Process(pub(super) sys::Process);
 

--- a/src/runtime/settings/list.rs
+++ b/src/runtime/settings/list.rs
@@ -1,0 +1,109 @@
+use core::fmt;
+
+use crate::{runtime::sys, Error};
+
+use super::Value;
+
+/// A list of [`Value`]s that can itself be a [`Value`] and thus be stored in a
+/// [`Map`](super::Map).
+#[repr(transparent)]
+pub struct List(pub(super) sys::SettingsList);
+
+impl fmt::Debug for List {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+impl Drop for List {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: The handle is valid and we own it, so it's our responsibility
+        // to free it.
+        unsafe { sys::settings_list_free(self.0) }
+    }
+}
+
+impl Clone for List {
+    #[inline]
+    fn clone(&self) -> Self {
+        // SAFETY: The handle is valid, so we can safely copy it.
+        Self(unsafe { sys::settings_list_copy(self.0) })
+    }
+}
+
+impl Default for List {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl List {
+    /// Creates a new empty settings list.
+    #[inline]
+    pub fn new() -> Self {
+        // SAFETY: This is always safe to call.
+        Self(unsafe { sys::settings_list_new() })
+    }
+
+    /// Returns the number of values in the list.
+    #[inline]
+    pub fn len(&self) -> u64 {
+        // SAFETY: The handle is valid, so we can safely call this function.
+        unsafe { sys::settings_list_len(self.0) }
+    }
+
+    /// Returns [`true`] if the list has a length of 0.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a copy of the value at the given index. Returns [`None`] if the
+    /// index is out of bounds. Any changes to it are only perceived if it's
+    /// stored back.
+    #[inline]
+    pub fn get(&self, index: u64) -> Option<Value> {
+        // SAFETY: The settings list handle is valid.
+        unsafe { sys::settings_list_get(self.0, index).map(Value) }
+    }
+
+    /// Pushes a copy of the value to the end of the list.
+    #[inline]
+    pub fn push(&self, value: &Value) {
+        // SAFETY: The settings list handle is valid and the value handle is
+        // valid.
+        unsafe { sys::settings_list_push(self.0, value.0) }
+    }
+
+    /// Inserts a copy of the value at the given index, pushing all values at
+    /// and after the index one position further. Returns an error if the index
+    /// is out of bounds. You may specify an index that is equal to the length
+    /// of the list to append the value to the end of the list.
+    #[inline]
+    pub fn insert(&self, index: u64, value: &Value) -> Result<(), Error> {
+        // SAFETY: The settings list handle is valid and the value handle is
+        // valid.
+        unsafe {
+            if sys::settings_list_insert(self.0, index, value.0) {
+                Ok(())
+            } else {
+                Err(Error {})
+            }
+        }
+    }
+
+    /// Returns an iterator over the values in the list. Every value is a copy,
+    /// so any changes to them are only perceived if they are stored back. The
+    /// iterator is double-ended, so it can be iterated backwards as well. While
+    /// it's possible to modify the list while iterating over it, it's not
+    /// recommended to do so, as the iterator might skip values or return
+    /// duplicate values. In that case it's better to clone the list before and
+    /// iterate over the clone or use [`get`](Self::get) to manually handle the
+    /// iteration.
+    #[inline]
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = Value> + '_ {
+        (0..self.len()).flat_map(|i| self.get(i))
+    }
+}

--- a/src/runtime/settings/mod.rs
+++ b/src/runtime/settings/mod.rs
@@ -55,9 +55,11 @@
 //! Check the [`Map`](struct@Map) struct for more information.
 
 pub mod gui;
+mod list;
 mod map;
 mod value;
 
 pub use gui::Gui;
+pub use list::*;
 pub use map::*;
 pub use value::*;

--- a/src/runtime/settings/value.rs
+++ b/src/runtime/settings/value.rs
@@ -1,16 +1,56 @@
-use core::mem::MaybeUninit;
+use core::{fmt, mem::MaybeUninit};
 
 use arrayvec::ArrayString;
 
 use crate::{runtime::sys, Error};
 
-use super::Map;
+use super::{List, Map};
 
 /// A value of a setting. This can be a value of any type that a setting can
-/// hold. Currently booleans, strings and maps are supported.
-#[derive(Debug)]
+/// hold. Currently this is either a [`Map`], a [`List`], a [`bool`], an
+/// [`i64`], an [`f64`], or a string.
 #[repr(transparent)]
 pub struct Value(pub(super) sys::SettingValue);
+
+impl fmt::Debug for Value {
+    #[allow(clippy::collapsible_match)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: Do a type check first.
+        if let Some(v) = self.get_map() {
+            fmt::Debug::fmt(&v, f)
+        } else if let Some(v) = self.get_list() {
+            fmt::Debug::fmt(&v, f)
+        } else if let Some(v) = self.get_bool() {
+            fmt::Debug::fmt(&v, f)
+        } else if let Some(v) = self.get_i64() {
+            fmt::Debug::fmt(&v, f)
+        } else if let Some(v) = self.get_f64() {
+            fmt::Debug::fmt(&v, f)
+        } else {
+            if let Some(v) = self.get_array_string::<128>() {
+                if let Ok(v) = v {
+                    return fmt::Debug::fmt(&v, f);
+                }
+                #[cfg(not(feature = "alloc"))]
+                return f.write_str("<Long string>");
+            }
+            #[cfg(feature = "alloc")]
+            if let Some(v) = self.get_string() {
+                return fmt::Debug::fmt(&v, f);
+            }
+
+            f.write_str("<Unknown>")
+        }
+    }
+}
+
+impl Clone for Value {
+    #[inline]
+    fn clone(&self) -> Self {
+        // SAFETY: The handle is valid, so we can safely copy it.
+        Self(unsafe { sys::setting_value_copy(self.0) })
+    }
+}
 
 impl Value {
     /// Creates a new setting value from a value of a supported type. The value
@@ -21,7 +61,7 @@ impl Value {
         value.into()
     }
 
-    /// Returns the value as a map if it is a map. The map is a copy, so any
+    /// Returns the value as a [`Map`] if it is a map. The map is a copy, so any
     /// changes to it are not reflected in the setting value.
     #[inline]
     pub fn get_map(&self) -> Option<Map> {
@@ -39,7 +79,25 @@ impl Value {
         }
     }
 
-    /// Returns the value as a boolean if it is a boolean.
+    /// Returns the value as a [`List`] if it is a list. The list is a copy, so
+    /// any changes to it are not reflected in the setting value.
+    #[inline]
+    pub fn get_list(&self) -> Option<List> {
+        // SAFETY: The handle is valid. We provide a valid pointer to a list.
+        // After the function call we check the return value and if it's true,
+        // the list is initialized and we can return it. We also own the list
+        // handle, so it's our responsibility to free it.
+        unsafe {
+            let mut out = MaybeUninit::uninit();
+            if sys::setting_value_get_list(self.0, out.as_mut_ptr()) {
+                Some(List(out.assume_init()))
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Returns the value as a [`bool`] if it is a boolean.
     #[inline]
     pub fn get_bool(&self) -> Option<bool> {
         // SAFETY: The handle is valid. We provide a valid pointer to a boolean.
@@ -55,7 +113,39 @@ impl Value {
         }
     }
 
-    /// Returns the value as a string if it is a string.
+    /// Returns the value as an [`i64`] if it is a 64-bit signed integer.
+    #[inline]
+    pub fn get_i64(&self) -> Option<i64> {
+        // SAFETY: The handle is valid. We provide a valid pointer to a i64.
+        // After the function call we check the return value and if it's true,
+        // the i64 is initialized and we can return it.
+        unsafe {
+            let mut out = MaybeUninit::uninit();
+            if sys::setting_value_get_i64(self.0, out.as_mut_ptr()) {
+                Some(out.assume_init())
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Returns the value as an [`f64`] if it is a 64-bit floating point number.
+    #[inline]
+    pub fn get_f64(&self) -> Option<f64> {
+        // SAFETY: The handle is valid. We provide a valid pointer to a f64.
+        // After the function call we check the return value and if it's true,
+        // the f64 is initialized and we can return it.
+        unsafe {
+            let mut out = MaybeUninit::uninit();
+            if sys::setting_value_get_f64(self.0, out.as_mut_ptr()) {
+                Some(out.assume_init())
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Returns the value as a [`String`](alloc::string::String) if it is a string.
     #[cfg(feature = "alloc")]
     #[inline]
     pub fn get_string(&self) -> Option<alloc::string::String> {
@@ -80,9 +170,9 @@ impl Value {
         }
     }
 
-    /// Returns the value as an array backed string if it is a string. Returns
-    /// an error if the string is too long. The constant `N` determines the
-    /// maximum length of the string in bytes.
+    /// Returns the value as an [`ArrayString`] if it is a string. Returns an
+    /// error if the string is too long. The constant `N` determines the maximum
+    /// length of the string in bytes.
     #[inline]
     pub fn get_array_string<const N: usize>(&self) -> Option<Result<ArrayString<N>, Error>> {
         // SAFETY: The handle is valid. We provide a pointer to our buffer and
@@ -124,11 +214,36 @@ impl From<&Map> for Value {
     }
 }
 
+impl From<&List> for Value {
+    #[inline]
+    fn from(value: &List) -> Self {
+        // SAFETY: The handle is valid. We retain ownership of the handle, so we
+        // only take a reference to a List. We own the returned value now.
+        Self(unsafe { sys::setting_value_new_list(value.0) })
+    }
+}
+
 impl From<bool> for Value {
     #[inline]
     fn from(value: bool) -> Self {
         // SAFETY: This is always safe to call. We own the returned value now.
         Self(unsafe { sys::setting_value_new_bool(value) })
+    }
+}
+
+impl From<i64> for Value {
+    #[inline]
+    fn from(value: i64) -> Self {
+        // SAFETY: This is always safe to call. We own the returned value now.
+        Self(unsafe { sys::setting_value_new_i64(value) })
+    }
+}
+
+impl From<f64> for Value {
+    #[inline]
+    fn from(value: f64) -> Self {
+        // SAFETY: This is always safe to call. We own the returned value now.
+        Self(unsafe { sys::setting_value_new_f64(value) })
     }
 }
 


### PR DESCRIPTION
This adds support for `List`, `i64`, and `f64` values. It also extends the `Map` API to support iteration. All types also now implement `Clone` and `Debug`.