### PR TITLE
Added support for `future` for emulators

### DIFF
--- a/src/emulator/gba/mod.rs
+++ b/src/emulator/gba/mod.rs
@@ -7,7 +7,7 @@ use core::{
     task::{Context, Poll},
 };
 
-use crate::{Address, Error, Process};
+use crate::{future::retry, Address, Error, Process};
 use bytemuck::CheckedBitPattern;
 
 mod emuhawk;
@@ -50,6 +50,21 @@ impl Emulator {
             state: Cell::new(state),
             ram_base: Cell::new(None),
         })
+    }
+
+    /// Asynchronously awaits attaching to a target emulator,
+    /// yielding back to the runtime between each try.
+    ///
+    /// Supported emulators are:
+    /// - VisualBoyAdvance
+    /// - VisualBoyAdvance-M
+    /// - mGBA
+    /// - NO$GBA
+    /// - BizHawk
+    /// - Retroarch, with one of the following cores: `vbam_libretro.dll`, `vba_next_libretro.dll`,
+    /// `mednafen_gba_libretro.dll`, `mgba_libretro.dll`, `gpsp_libretro.dll`
+    pub async fn wait_attach() -> Self {
+        retry(Self::attach).await
     }
 
     /// Checks whether the emulator is still open. If it is not open anymore,

--- a/src/emulator/gba/mod.rs
+++ b/src/emulator/gba/mod.rs
@@ -1,5 +1,12 @@
 //! Support for attaching to Nintendo Gameboy Advance emulators.
 
+use core::{
+    cell::Cell,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use crate::{Address, Error, Process};
 use bytemuck::CheckedBitPattern;
 
@@ -15,9 +22,9 @@ pub struct Emulator {
     /// The attached emulator process
     process: Process,
     /// An enum stating which emulator is currently attached
-    state: State,
+    state: Cell<State>,
     /// The memory address of the emulated RAM
-    ram_base: Option<[Address; 2]>, // [ewram, iwram]
+    ram_base: Cell<Option<[Address; 2]>>, // [ewram, iwram]
 }
 
 impl Emulator {
@@ -40,8 +47,8 @@ impl Emulator {
 
         Some(Self {
             process,
-            state,
-            ram_base: None,
+            state: Cell::new(state),
+            ram_base: Cell::new(None),
         })
     }
 
@@ -51,13 +58,24 @@ impl Emulator {
         self.process.is_open()
     }
 
+    /// Executes a future until the emulator process closes.
+    pub const fn until_closes<F>(&self, future: F) -> UntilEmulatorCloses<'_, F> {
+        UntilEmulatorCloses {
+            emulator: self,
+            future,
+        }
+    }
+
     /// Calls the internal routines needed in order to find (and update, if
     /// needed) the address of the emulated RAM.
     ///
     /// Returns true if successful, false otherwise.
-    pub fn update(&mut self) -> bool {
-        if self.ram_base.is_none() {
-            self.ram_base = match match &mut self.state {
+    pub fn update(&self) -> bool {
+        let mut ram_base = self.ram_base.get();
+        let mut state = self.state.get();
+
+        if ram_base.is_none() {
+            ram_base = match match &mut state {
                 State::VisualBoyAdvance(x) => x.find_ram(&self.process),
                 State::Mgba(x) => x.find_ram(&self.process),
                 State::NoCashGba(x) => x.find_ram(&self.process),
@@ -70,21 +88,23 @@ impl Emulator {
             };
         }
 
-        let success = match &self.state {
-            State::VisualBoyAdvance(x) => x.keep_alive(&self.process, &mut self.ram_base),
-            State::Mgba(x) => x.keep_alive(&self.process, &self.ram_base),
-            State::NoCashGba(x) => x.keep_alive(&self.process, &mut self.ram_base),
+        let success = match &state {
+            State::VisualBoyAdvance(x) => x.keep_alive(&self.process, &mut ram_base),
+            State::Mgba(x) => x.keep_alive(&self.process, &ram_base),
+            State::NoCashGba(x) => x.keep_alive(&self.process, &mut ram_base),
             State::Retroarch(x) => x.keep_alive(&self.process),
-            State::EmuHawk(x) => x.keep_alive(&self.process, &self.ram_base),
-            State::Mednafen(x) => x.keep_alive(&self.process, &mut self.ram_base),
+            State::EmuHawk(x) => x.keep_alive(&self.process, &ram_base),
+            State::Mednafen(x) => x.keep_alive(&self.process, &mut ram_base),
         };
 
-        match success {
-            true => true,
-            false => {
-                self.ram_base = None;
-                false
-            }
+        self.state.set(state);
+
+        if success {
+            self.ram_base.set(ram_base);
+            true
+        } else {
+            self.ram_base.set(None);
+            false
         }
     }
 
@@ -120,9 +140,7 @@ impl Emulator {
             return Err(Error {});
         }
 
-        let Some([ewram, _]) = self.ram_base else {
-            return Err(Error {});
-        };
+        let [ewram, _] = self.ram_base.get().ok_or(Error {})?;
         let end_offset = offset.checked_sub(0x02000000).unwrap_or(offset);
 
         self.process.read(ewram + end_offset)
@@ -144,12 +162,29 @@ impl Emulator {
             return Err(Error {});
         }
 
-        let Some([_, iwram]) = self.ram_base else {
-            return Err(Error {});
-        };
+        let [_, iwram] = self.ram_base.get().ok_or(Error {})?;
         let end_offset = offset.checked_sub(0x03000000).unwrap_or(offset);
 
         self.process.read(iwram + end_offset)
+    }
+}
+
+/// A future that executes a future until the emulator closes.
+pub struct UntilEmulatorCloses<'a, F> {
+    emulator: &'a Emulator,
+    future: F,
+}
+
+impl<F: Future<Output = ()>> Future for UntilEmulatorCloses<'_, F> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if !self.emulator.is_open() {
+            return Poll::Ready(());
+        }
+        self.emulator.update();
+        // SAFETY: We are simply projecting the Pin.
+        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().future).poll(cx) }
     }
 }
 

--- a/src/emulator/gcn/mod.rs
+++ b/src/emulator/gcn/mod.rs
@@ -1,5 +1,12 @@
 //! Support for attaching to Nintendo Gamecube emulators.
 
+use core::{
+    cell::Cell,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use crate::{Address, Endian, Error, FromEndian, Process};
 use bytemuck::CheckedBitPattern;
 
@@ -11,11 +18,11 @@ pub struct Emulator {
     /// The attached emulator process
     process: Process,
     /// An enum stating which emulator is currently attached
-    state: State,
+    state: Cell<State>,
     /// The memory address of the emulated RAM
-    mem1_base: Option<Address>,
+    mem1_base: Cell<Option<Address>>,
     /// The endianness used by the emulator process
-    endian: Endian,
+    endian: Cell<Endian>,
 }
 
 impl Emulator {
@@ -33,9 +40,9 @@ impl Emulator {
 
         Some(Self {
             process,
-            state,
-            mem1_base: None,
-            endian: Endian::Big, // Endianness is usually Big across all GCN emulators
+            state: Cell::new(state),
+            mem1_base: Cell::new(None),
+            endian: Cell::new(Endian::Big), // Endianness is usually Big across all GCN emulators
         })
     }
 
@@ -45,32 +52,48 @@ impl Emulator {
         self.process.is_open()
     }
 
+    /// Executes a future until the emulator process closes.
+    pub const fn until_closes<F>(&self, future: F) -> UntilEmulatorCloses<'_, F> {
+        UntilEmulatorCloses {
+            emulator: self,
+            future,
+        }
+    }
+
     /// Calls the internal routines needed in order to find (and update, if
     /// needed) the address of the emulated RAM.
     ///
     /// Returns true if successful, false otherwise.
-    pub fn update(&mut self) -> bool {
-        if self.mem1_base.is_none() {
-            let mem1_base = match &mut self.state {
-                State::Dolphin(x) => x.find_ram(&self.process, &mut self.endian),
-                State::Retroarch(x) => x.find_ram(&self.process, &mut self.endian),
+    pub fn update(&self) -> bool {
+        let mut mem1_base = self.mem1_base.get();
+        let mut state = self.state.get();
+        let mut endian = self.endian.get();
+
+        if mem1_base.is_none() {
+            mem1_base = match match &mut state {
+                State::Dolphin(x) => x.find_ram(&self.process, &mut endian),
+                State::Retroarch(x) => x.find_ram(&self.process, &mut endian),
+            } {
+                None => return false,
+                something => something,
             };
-            if mem1_base.is_none() {
-                return false;
-            }
-            self.mem1_base = mem1_base;
         }
 
-        let success = match &self.state {
-            State::Dolphin(x) => x.keep_alive(&self.process, &self.mem1_base),
-            State::Retroarch(x) => x.keep_alive(&self.process, &self.mem1_base),
+        let success = match &state {
+            State::Dolphin(x) => x.keep_alive(&self.process, &mem1_base),
+            State::Retroarch(x) => x.keep_alive(&self.process, &mem1_base),
         };
 
-        if !success {
-            self.mem1_base = None;
-        }
+        self.state.set(state);
+        self.endian.set(endian);
 
-        success
+        if success {
+            self.mem1_base.set(mem1_base);
+            true
+        } else {
+            self.mem1_base.set(None);
+            false
+        }
     }
 
     /// Reads raw data from the emulated RAM ignoring all endianness settings.
@@ -92,7 +115,7 @@ impl Emulator {
             return Err(Error {});
         }
 
-        let mem1 = self.mem1_base.ok_or(Error {})?;
+        let mem1 = self.mem1_base.get().ok_or(Error {})?;
         let end_offset = offset.checked_sub(0x80000000).unwrap_or(offset);
 
         self.process.read(mem1 + end_offset)
@@ -112,7 +135,26 @@ impl Emulator {
     pub fn read<T: CheckedBitPattern + FromEndian>(&self, offset: u32) -> Result<T, Error> {
         Ok(self
             .read_ignoring_endianness::<T>(offset)?
-            .from_endian(self.endian))
+            .from_endian(self.endian.get()))
+    }
+}
+
+/// A future that executes a future until the emulator closes.
+pub struct UntilEmulatorCloses<'a, F> {
+    emulator: &'a Emulator,
+    future: F,
+}
+
+impl<F: Future<Output = ()>> Future for UntilEmulatorCloses<'_, F> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if !self.emulator.is_open() {
+            return Poll::Ready(());
+        }
+        self.emulator.update();
+        // SAFETY: We are simply projecting the Pin.
+        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().future).poll(cx) }
     }
 }
 

--- a/src/emulator/gcn/mod.rs
+++ b/src/emulator/gcn/mod.rs
@@ -7,7 +7,7 @@ use core::{
     task::{Context, Poll},
 };
 
-use crate::{Address, Endian, Error, FromEndian, Process};
+use crate::{future::retry, Address, Endian, Error, FromEndian, Process};
 use bytemuck::CheckedBitPattern;
 
 mod dolphin;
@@ -44,6 +44,16 @@ impl Emulator {
             mem1_base: Cell::new(None),
             endian: Cell::new(Endian::Big), // Endianness is usually Big across all GCN emulators
         })
+    }
+
+    /// Asynchronously awaits attaching to a target emulator,
+    /// yielding back to the runtime between each try.
+    ///
+    /// Supported emulators are:
+    /// - Dolphin
+    /// - Retroarch (using the `dolphin_libretro.dll` core)
+    pub async fn wait_attach() -> Self {
+        retry(Self::attach).await
     }
 
     /// Checks whether the emulator is still open. If it is not open anymore,

--- a/src/emulator/genesis/mod.rs
+++ b/src/emulator/genesis/mod.rs
@@ -8,7 +8,7 @@ use core::{
     task::{Context, Poll},
 };
 
-use crate::{Address, Endian, Error, FromEndian, Process};
+use crate::{future::retry, Address, Endian, Error, FromEndian, Process};
 use bytemuck::CheckedBitPattern;
 
 mod blastem;
@@ -51,6 +51,19 @@ impl Emulator {
             wram_base: Cell::new(None),
             endian: Cell::new(Endian::Little), // Endianness is supposed to be Little, until stated otherwise in the code
         })
+    }
+
+    /// Asynchronously awaits attaching to a target emulator,
+    /// yielding back to the runtime between each try.
+    ///
+    /// Supported emulators are:
+    /// - Retroarch
+    /// - SEGA Classics / SEGA Game Room
+    /// - Fusion
+    /// - Gens
+    /// - BlastEm
+    pub async fn wait_attach() -> Self {
+        retry(Self::attach).await
     }
 
     /// Checks whether the emulator is still open. If it is not open anymore,

--- a/src/emulator/ps1/mod.rs
+++ b/src/emulator/ps1/mod.rs
@@ -1,5 +1,12 @@
 //! Support for attaching to Playstation 1 emulators.
 
+use core::{
+    cell::Cell,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use crate::{Address, Error, Process};
 use bytemuck::CheckedBitPattern;
 
@@ -16,9 +23,9 @@ pub struct Emulator {
     /// The attached emulator process
     process: Process,
     /// An enum stating which emulator is currently attached
-    state: State,
+    state: Cell<State>,
     /// The memory address of the emulated RAM
-    ram_base: Option<Address>,
+    ram_base: Cell<Option<Address>>,
 }
 
 impl Emulator {
@@ -40,8 +47,8 @@ impl Emulator {
 
         Some(Self {
             process,
-            state,
-            ram_base: None,
+            state: Cell::new(state),
+            ram_base: Cell::new(None),
         })
     }
 
@@ -51,13 +58,24 @@ impl Emulator {
         self.process.is_open()
     }
 
+    /// Executes a future until the emulator process closes.
+    pub const fn until_closes<F>(&self, future: F) -> UntilEmulatorCloses<'_, F> {
+        UntilEmulatorCloses {
+            emulator: self,
+            future,
+        }
+    }
+
     /// Calls the internal routines needed in order to find (and update, if
     /// needed) the address of the emulated RAM.
     ///
     /// Returns true if successful, false otherwise.
-    pub fn update(&mut self) -> bool {
-        if self.ram_base.is_none() {
-            self.ram_base = match match &mut self.state {
+    pub fn update(&self) -> bool {
+        let mut ram_base = self.ram_base.get();
+        let mut state = self.state.get();
+
+        if ram_base.is_none() {
+            ram_base = match match &mut state {
                 State::Epsxe(x) => x.find_ram(&self.process),
                 State::PsxFin(x) => x.find_ram(&self.process),
                 State::Duckstation(x) => x.find_ram(&self.process),
@@ -71,20 +89,23 @@ impl Emulator {
             };
         }
 
-        let success = match &self.state {
+        let success = match &state {
             State::Epsxe(x) => x.keep_alive(),
             State::PsxFin(x) => x.keep_alive(),
-            State::Duckstation(x) => x.keep_alive(&self.process, &mut self.ram_base),
+            State::Duckstation(x) => x.keep_alive(&self.process, &mut ram_base),
             State::Retroarch(x) => x.keep_alive(&self.process),
             State::PcsxRedux(x) => x.keep_alive(&self.process),
             State::Xebra(x) => x.keep_alive(),
             State::Mednafen(x) => x.keep_alive(),
         };
 
+        self.state.set(state);
+
         if success {
+            self.ram_base.set(ram_base);
             true
         } else {
-            self.ram_base = None;
+            self.ram_base.set(None);
             false
         }
     }
@@ -106,13 +127,29 @@ impl Emulator {
             return Err(Error {});
         };
 
-        let Some(ram_base) = self.ram_base else {
-            return Err(Error {});
-        };
-
+        let ram_base = self.ram_base.get().ok_or(Error {})?;
         let end_offset = offset.checked_sub(0x80000000).unwrap_or(offset);
 
         self.process.read(ram_base + end_offset)
+    }
+}
+
+/// A future that executes a future until the emulator closes.
+pub struct UntilEmulatorCloses<'a, F> {
+    emulator: &'a Emulator,
+    future: F,
+}
+
+impl<F: Future<Output = ()>> Future for UntilEmulatorCloses<'_, F> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if !self.emulator.is_open() {
+            return Poll::Ready(());
+        }
+        self.emulator.update();
+        // SAFETY: We are simply projecting the Pin.
+        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().future).poll(cx) }
     }
 }
 

--- a/src/emulator/ps1/mod.rs
+++ b/src/emulator/ps1/mod.rs
@@ -7,7 +7,7 @@ use core::{
     task::{Context, Poll},
 };
 
-use crate::{Address, Error, Process};
+use crate::{future::retry, Address, Error, Process};
 use bytemuck::CheckedBitPattern;
 
 mod duckstation;
@@ -37,6 +37,7 @@ impl Emulator {
     /// - ePSXe
     /// - pSX
     /// - Duckstation
+    /// - Mednafen
     /// - Retroarch (supported cores: Beetle-PSX, Swanstation, PCSX ReARMed)
     /// - PCSX-redux
     /// - XEBRA
@@ -50,6 +51,21 @@ impl Emulator {
             state: Cell::new(state),
             ram_base: Cell::new(None),
         })
+    }
+
+    /// Asynchronously awaits attaching to a target emulator,
+    /// yielding back to the runtime between each try.
+    ///
+    /// Supported emulators are:
+    /// - ePSXe
+    /// - pSX
+    /// - Duckstation
+    /// - Mednafen
+    /// - Retroarch (supported cores: Beetle-PSX, Swanstation, PCSX ReARMed)
+    /// - PCSX-redux
+    /// - XEBRA
+    pub async fn wait_attach() -> Self {
+        retry(Self::attach).await
     }
 
     /// Checks whether the emulator is still open. If it is not open anymore,

--- a/src/emulator/ps2/mod.rs
+++ b/src/emulator/ps2/mod.rs
@@ -7,7 +7,7 @@ use core::{
     task::{Context, Poll},
 };
 
-use crate::{Address, Error, Process};
+use crate::{future::retry, Address, Error, Process};
 use bytemuck::CheckedBitPattern;
 
 mod pcsx2;
@@ -41,6 +41,16 @@ impl Emulator {
             state: Cell::new(state),
             ram_base: Cell::new(None),
         })
+    }
+
+    /// Asynchronously awaits attaching to a target emulator,
+    /// yielding back to the runtime between each try.
+    ///
+    /// Supported emulators are:
+    /// - PCSX2
+    /// - Retroarch (64-bit version, using the `pcsx2_libretro.dll` core)
+    pub async fn wait_attach() -> Self {
+        retry(Self::attach).await
     }
 
     /// Checks whether the emulator is still open. If it is not open anymore,

--- a/src/emulator/sms/mod.rs
+++ b/src/emulator/sms/mod.rs
@@ -7,7 +7,7 @@ use core::{
     task::{Context, Poll},
 };
 
-use crate::{Address, Error, Process};
+use crate::{future::retry, Address, Error, Process};
 use bytemuck::CheckedBitPattern;
 
 mod blastem;
@@ -45,6 +45,18 @@ impl Emulator {
             state: Cell::new(state),
             ram_base: Cell::new(None),
         })
+    }
+
+    /// Asynchronously awaits attaching to a target emulator,
+    /// yielding back to the runtime between each try.
+    ///
+    /// Supported emulators are:
+    /// - Retroarch, with one of the following cores: `genesis_plus_gx_libretro.dll`,
+    /// `genesis_plus_gx_wide_libretro.dll`, `picodrive_libretro.dll`, `smsplus_libretro.dll`, `gearsystem_libretro.dll`
+    /// - Fusion
+    /// - BlastEm
+    pub async fn wait_attach() -> Self {
+        retry(Self::attach).await
     }
 
     /// Checks whether the emulator is still open. If it is not open anymore,

--- a/src/emulator/sms/mod.rs
+++ b/src/emulator/sms/mod.rs
@@ -1,5 +1,7 @@
 //! Support for attaching to SEGA Master System / SEGA GameGear emulators.
 
+use core::{cell::Cell, pin::Pin, future::Future, task::{Context, Poll}};
+
 use crate::{Address, Error, Process};
 use bytemuck::CheckedBitPattern;
 
@@ -13,9 +15,9 @@ pub struct Emulator {
     /// The attached emulator process
     process: Process,
     /// An enum stating which emulator is currently attached
-    state: State,
+    state: Cell<State>,
     /// The memory address of the emulated RAM
-    ram_base: Option<Address>,
+    ram_base: Cell<Option<Address>>,
 }
 
 impl Emulator {
@@ -35,8 +37,8 @@ impl Emulator {
 
         Some(Self {
             process,
-            state,
-            ram_base: None,
+            state: Cell::new(state),
+            ram_base: Cell::new(None),
         })
     }
 
@@ -46,13 +48,24 @@ impl Emulator {
         self.process.is_open()
     }
 
+    /// Executes a future until the emulator process closes.
+    pub const fn until_closes<F>(&self, future: F) -> UntilEmulatorCloses<'_, F> {
+        UntilEmulatorCloses {
+            emulator: self,
+            future,
+        }
+    }
+
     /// Calls the internal routines needed in order to find (and update, if
     /// needed) the address of the emulated RAM.
     ///
     /// Returns true if successful, false otherwise.
-    pub fn update(&mut self) -> bool {
-        if self.ram_base.is_none() {
-            self.ram_base = match match &mut self.state {
+    pub fn update(&self) -> bool {
+        let mut ram_base = self.ram_base.get();
+        let mut state = self.state.get();
+
+        if ram_base.is_none() {
+            ram_base = match match &mut state {
                 State::Retroarch(x) => x.find_ram(&self.process),
                 State::Fusion(x) => x.find_ram(&self.process),
                 State::BlastEm(x) => x.find_ram(&self.process),
@@ -63,17 +76,18 @@ impl Emulator {
             };
         }
 
-        let success = match &self.state {
+        let success = match &state {
             State::Retroarch(x) => x.keep_alive(&self.process),
-            State::Fusion(x) => x.keep_alive(&self.process, &mut self.ram_base),
+            State::Fusion(x) => x.keep_alive(&self.process, &mut ram_base),
             State::BlastEm(x) => x.keep_alive(),
             State::Mednafen(x) => x.keep_alive(),
         };
 
         if success {
+            self.ram_base.set(ram_base);
             true
         } else {
-            self.ram_base = None;
+            self.ram_base.set(None);
             false
         }
     }
@@ -91,10 +105,29 @@ impl Emulator {
             return Err(Error {});
         }
 
-        let wram = self.ram_base.ok_or(Error {})?;
+        let wram = self.ram_base.get().ok_or(Error {})?;
         let end_offset = offset.checked_sub(0xC000).unwrap_or(offset);
 
         self.process.read(wram + end_offset)
+    }
+}
+
+/// A future that executes a future until the emulator closes.
+pub struct UntilEmulatorCloses<'a, F> {
+    emulator: &'a Emulator,
+    future: F,
+}
+
+impl<F: Future<Output = ()>> Future for UntilEmulatorCloses<'_, F> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if !self.emulator.is_open() {
+            return Poll::Ready(());
+        }
+        self.emulator.update();
+        // SAFETY: We are simply projecting the Pin.
+        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().future).poll(cx) }
     }
 }
 

--- a/src/emulator/sms/mod.rs
+++ b/src/emulator/sms/mod.rs
@@ -1,6 +1,11 @@
 //! Support for attaching to SEGA Master System / SEGA GameGear emulators.
 
-use core::{cell::Cell, pin::Pin, future::Future, task::{Context, Poll}};
+use core::{
+    cell::Cell,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use crate::{Address, Error, Process};
 use bytemuck::CheckedBitPattern;

--- a/src/emulator/wii/mod.rs
+++ b/src/emulator/wii/mod.rs
@@ -7,7 +7,7 @@ use core::{
     task::{Context, Poll},
 };
 
-use crate::{Address, Endian, Error, FromEndian, Process};
+use crate::{future::retry, Address, Endian, Error, FromEndian, Process};
 use bytemuck::CheckedBitPattern;
 
 mod dolphin;
@@ -45,6 +45,16 @@ impl Emulator {
             ram_base: Cell::new(None),      // [MEM1, MEM2]
             endian: Cell::new(Endian::Big), // Endianness is usually Big in Wii emulators
         })
+    }
+
+    /// Asynchronously awaits attaching to a target emulator,
+    /// yielding back to the runtime between each try.
+    ///
+    /// Supported emulators are:
+    /// - Dolphin
+    /// - Retroarch (using the `dolphin_libretro.dll` core)
+    pub async fn wait_attach() -> Self {
+        retry(Self::attach).await
     }
 
     /// Checks whether the emulator is still open. If it is not open anymore,

--- a/src/emulator/wii/mod.rs
+++ b/src/emulator/wii/mod.rs
@@ -113,9 +113,9 @@ impl Emulator {
     ///
     /// This call is meant to be used by experienced users.
     pub fn read_ignoring_endianness<T: CheckedBitPattern>(&self, address: u32) -> Result<T, Error> {
-        if address >= 0x80000000 && address <= 0x817FFFFF {
+        if (0x80000000..0x81800000).contains(&address) {
             self.read_ignoring_endianness_from_mem_1(address)
-        } else if address >= 0x90000000 && address <= 0x93FFFFFF {
+        } else if (0x90000000..0x94000000).contains(&address) {
             self.read_ignoring_endianness_from_mem_2(address)
         } else {
             Err(Error {})
@@ -186,7 +186,7 @@ impl Emulator {
         &self,
         address: u32,
     ) -> Result<T, Error> {
-        if address < 0x80000000 || address > 0x817FFFFF {
+        if !(0x80000000..0x81800000).contains(&address) {
             return Err(Error {});
         }
 
@@ -211,7 +211,7 @@ impl Emulator {
         &self,
         address: u32,
     ) -> Result<T, Error> {
-        if address < 0x90000000 || address > 0x93FFFFFF {
+        if !(0x90000000..0x94000000).contains(&address) {
             return Err(Error {});
         }
         let [_, mem2] = self.ram_base.get().ok_or(Error {})?;


### PR DESCRIPTION
This commit adds support for `future` when coding autosplitters for emulators, allowing to code similarly compared to native pc games.
The internal `update()` function, which is usually necessary in emulators to ensure correct updating of the main `ram_base` address, gets called automatically in this case, so this also removes the need to manually call said function on every iteration of the main loop.

The downside is using a internal mutability for the main `state` and `ram_base` variable, however they are not publicly accessible so this should not raise many concerns.

```rust
async fn main() {
    loop {
        let emulator = ps1::Emulator::wait_attach().await;
        emulator.until_closes(async {
            loop {
                // TODO: Do something on every tick.
               next_tick().await;
            }
        }).await;
    }
}
```