### PR TITLE
More uniform methods for emulators

### DIFF
--- a/src/emulator/gba/mod.rs
+++ b/src/emulator/gba/mod.rs
@@ -196,16 +196,20 @@ pub struct UntilEmulatorCloses<'a, F> {
     future: F,
 }
 
-impl<F: Future<Output = ()>> Future for UntilEmulatorCloses<'_, F> {
-    type Output = ();
+impl<T, F: Future<Output = T>> Future for UntilEmulatorCloses<'_, F> {
+    type Output = Option<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if !self.emulator.is_open() {
-            return Poll::Ready(());
+            return Poll::Ready(None);
         }
         self.emulator.update();
         // SAFETY: We are simply projecting the Pin.
-        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().future).poll(cx) }
+        unsafe {
+            Pin::new_unchecked(&mut self.get_unchecked_mut().future)
+                .poll(cx)
+                .map(Some)
+        }
     }
 }
 

--- a/src/emulator/gba/mod.rs
+++ b/src/emulator/gba/mod.rs
@@ -3,6 +3,8 @@
 use core::{
     cell::Cell,
     future::Future,
+    mem::size_of,
+    ops::Sub,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -118,6 +120,38 @@ impl Emulator {
         success
     }
 
+    /// Converts a GBA memory address to a real memory address in the emulator process' virtual memory space
+    ///
+    /// Valid addresses range:
+    /// - from `0x02000000` to `0x0203FFFF` for EWRAM
+    /// - from `0x03000000` to `0x03007FFF` for IWRAM
+    pub fn get_address(&self, offset: u32) -> Result<Address, Error> {
+        match offset {
+            (0x02000000..=0x0203FFFF) => {
+                let r_offset = offset.sub(0x02000000);
+                let [ewram, _] = self.ram_base.get().ok_or(Error {})?;
+                Ok(ewram + r_offset)
+            }
+            (0x03000000..=0x03007FFF) => {
+                let r_offset = offset.sub(0x03000000);
+                let [_, iwram] = self.ram_base.get().ok_or(Error {})?;
+                Ok(iwram + r_offset)
+            }
+            _ => Err(Error {}),
+        }
+    }
+
+    /// Checks if a memory reading operation would exceed the memory bounds of the emulated system.
+    ///
+    /// Returns `true` if the read operation can be performed safely, `false` otherwise.
+    fn check_bounds<T>(&self, offset: u32) -> bool {
+        match offset {
+            (0x02000000..=0x0203FFFF) => offset + size_of::<T>() as u32 <= 0x02040000,
+            (0x03000000..=0x03007FFF) => offset + size_of::<T>() as u32 <= 0x03008000,
+            _ => false,
+        }
+    }
+
     /// Reads any value from the emulated RAM.
     ///
     /// The offset provided is meant to be the same memory address as usually mapped on the original hardware.
@@ -125,57 +159,33 @@ impl Emulator {
     /// - from `0x02000000` to `0x0203FFFF` for EWRAM
     /// - from `0x03000000` to `0x03007FFF` for IWRAM
     ///
-    /// Values outside these ranges will be considered invalid, and will make this method immediately return `Err()`.
+    /// Values outside these ranges are invalid, and will make this method immediately return `Err()`.
     pub fn read<T: CheckedBitPattern>(&self, offset: u32) -> Result<T, Error> {
-        match offset >> 24 {
-            2 => self.read_from_ewram(offset),
-            3 => self.read_from_iwram(offset),
-            _ => Err(Error {}),
+        match self.check_bounds::<T>(offset) {
+            true => self.process.read(self.get_address(offset)?),
+            false => Err(Error {}),
         }
     }
 
-    /// Reads any value from the EWRAM section of the emulated RAM.
-    ///
-    /// The offset provided can either be the relative offset from the
-    /// start of EWRAM, or a memory address as mapped on the original hardware.
-    ///
-    /// Valid addresses range from `0x02000000` to `0x0203FFFF`.
-    /// For example, providing an offset value of `0x3000` or `0x02003000`
-    /// will return the exact same value.
-    ///
-    /// Invalid offset values, or values outside the allowed ranges will
-    /// make this method immediately return `Err()`.
-    pub fn read_from_ewram<T: CheckedBitPattern>(&self, offset: u32) -> Result<T, Error> {
-        if (offset > 0x3FFFF && offset < 0x02000000) || offset > 0x0203FFFF {
-            return Err(Error {});
-        }
-
-        let [ewram, _] = self.ram_base.get().ok_or(Error {})?;
-        let end_offset = offset.checked_sub(0x02000000).unwrap_or(offset);
-
-        self.process.read(ewram + end_offset)
+    /// Follows a path of pointers from the address given and reads a value of the type specified from
+    /// the process at the end of the pointer path.
+    pub fn read_pointer_path<T: CheckedBitPattern>(
+        &self,
+        base_address: u32,
+        path: &[u32],
+    ) -> Result<T, Error> {
+        self.read(self.deref_offsets(base_address, path)?)
     }
 
-    /// Reads any value from the IWRAM section of the emulated RAM.
-    ///
-    /// The offset provided can either be the relative offset from the
-    /// start of IWRAM, or a memory address as mapped on the original hardware.
-    ///
-    /// Valid addresses range from `0x03000000` to `0x03007FFF`.
-    /// For example, providing an offset value of `0x3000` or `0x03003000`
-    /// will return the exact same value.
-    ///
-    /// Invalid offset values, or values outside the allowed ranges will
-    /// make this method immediately return `Err()`.
-    pub fn read_from_iwram<T: CheckedBitPattern>(&self, offset: u32) -> Result<T, Error> {
-        if (offset > 0x7FFF && offset < 0x03000000) || offset > 0x03007FFF {
-            return Err(Error {});
+    /// Follows a path of pointers from the address given and returns the address at the end
+    /// of the pointer path
+    fn deref_offsets(&self, base_address: u32, path: &[u32]) -> Result<u32, Error> {
+        let mut address = base_address;
+        let (&last, path) = path.split_last().ok_or(Error {})?;
+        for &offset in path {
+            address = self.read::<u32>(address + offset)?;
         }
-
-        let [_, iwram] = self.ram_base.get().ok_or(Error {})?;
-        let end_offset = offset.checked_sub(0x03000000).unwrap_or(offset);
-
-        self.process.read(iwram + end_offset)
+        Ok(address + last)
     }
 }
 

--- a/src/emulator/gba/mod.rs
+++ b/src/emulator/gba/mod.rs
@@ -144,7 +144,7 @@ impl Emulator {
     /// Checks if a memory reading operation would exceed the memory bounds of the emulated system.
     ///
     /// Returns `true` if the read operation can be performed safely, `false` otherwise.
-    fn check_bounds<T>(&self, offset: u32) -> bool {
+    const fn check_bounds<T>(&self, offset: u32) -> bool {
         match offset {
             (0x02000000..=0x0203FFFF) => offset + size_of::<T>() as u32 <= 0x02040000,
             (0x03000000..=0x03007FFF) => offset + size_of::<T>() as u32 <= 0x03008000,

--- a/src/emulator/gcn/mod.rs
+++ b/src/emulator/gcn/mod.rs
@@ -3,6 +3,8 @@
 use core::{
     cell::Cell,
     future::Future,
+    mem::size_of,
+    ops::Sub,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -106,46 +108,82 @@ impl Emulator {
         }
     }
 
+    /// Converts a GameCube memory address to a real memory address in the emulator process' virtual memory space
+    ///
+    /// Valid addresses range from `0x80000000` to `0x817FFFFF`.
+    pub fn get_address(&self, offset: u32) -> Result<Address, Error> {
+        match offset {
+            (0x80000000..=0x817FFFFF) => {
+                Ok(self.mem1_base.get().ok_or(Error {})? + offset.sub(0x80000000))
+            }
+            _ => Err(Error {}),
+        }
+    }
+
+    /// Checks if a memory reading operation would exceed the memory bounds of the emulated system.
+    ///
+    /// Returns `true` if the read operation can be performed safely, `false` otherwise.
+    fn check_bounds<T>(&self, offset: u32) -> bool {
+        match offset {
+            (0x80000000..=0x817FFFFF) => offset + size_of::<T>() as u32 <= 0x81800000,
+            _ => false,
+        }
+    }
+
     /// Reads raw data from the emulated RAM ignoring all endianness settings.
     /// The same call, performed on two different emulators, might return different
     /// results due to the endianness used by the emulator.
     ///
-    /// The offset provided is meant to be the same used on the original,
+    /// The offset provided is meant to be the same address as mapped on the original,
     /// big-endian system.
     ///
-    /// You can alternatively provide the memory address as usually mapped on the original hardware.
     /// Valid addresses for the Nintendo Gamecube range from `0x80000000` to `0x817FFFFF`.
     ///
-    /// Values below and up to `0x017FFFFF` are automatically assumed to be offsets from the memory's base address.
     /// Any other invalid value will make this method immediately return `Err()`.
     ///
     /// This call is meant to be used by experienced users.
     pub fn read_ignoring_endianness<T: CheckedBitPattern>(&self, offset: u32) -> Result<T, Error> {
-        if (0x01800000..0x80000000).contains(&offset) || offset >= 0x81800000 {
-            return Err(Error {});
+        match self.check_bounds::<T>(offset) {
+            true => self.process.read(self.get_address(offset)?),
+            false => Err(Error {}),
         }
-
-        let mem1 = self.mem1_base.get().ok_or(Error {})?;
-        let end_offset = offset.checked_sub(0x80000000).unwrap_or(offset);
-
-        self.process.read(mem1 + end_offset)
     }
 
-    /// Reads any value from the emulated RAM.
+    /// Reads raw data from the emulated RAM ignoring all endianness settings.
+    /// The same call, performed on two different emulators, might return different
+    /// results due to the endianness used by the emulator.
     ///
-    /// The offset provided is meant to be the same used on the original,
-    /// big-endian system. The call will automatically convert the offset and
-    /// the output value to little endian.
+    /// The offset provided is meant to be the same address as mapped on the original,
+    /// big-endian system.
     ///
-    /// You can alternatively provide the memory address as usually mapped on the original hardware.
     /// Valid addresses for the Nintendo Gamecube range from `0x80000000` to `0x817FFFFF`.
     ///
-    /// Values below and up to `0x017FFFFF` are automatically assumed to be offsets from the memory's base address.
     /// Any other invalid value will make this method immediately return `Err()`.
     pub fn read<T: CheckedBitPattern + FromEndian>(&self, offset: u32) -> Result<T, Error> {
         Ok(self
             .read_ignoring_endianness::<T>(offset)?
             .from_endian(self.endian.get()))
+    }
+
+    /// Follows a path of pointers from the address given and reads a value of the type specified from
+    /// the process at the end of the pointer path.
+    pub fn read_pointer_path<T: CheckedBitPattern + FromEndian>(
+        &self,
+        base_address: u32,
+        path: &[u32],
+    ) -> Result<T, Error> {
+        self.read(self.deref_offsets(base_address, path)?)
+    }
+
+    /// Follows a path of pointers from the address given and returns the address at the end
+    /// of the pointer path
+    fn deref_offsets(&self, base_address: u32, path: &[u32]) -> Result<u32, Error> {
+        let mut address = base_address;
+        let (&last, path) = path.split_last().ok_or(Error {})?;
+        for &offset in path {
+            address = self.read::<u32>(address + offset)?;
+        }
+        Ok(address + last)
     }
 }
 

--- a/src/emulator/gcn/mod.rs
+++ b/src/emulator/gcn/mod.rs
@@ -194,16 +194,20 @@ pub struct UntilEmulatorCloses<'a, F> {
     future: F,
 }
 
-impl<F: Future<Output = ()>> Future for UntilEmulatorCloses<'_, F> {
-    type Output = ();
+impl<T, F: Future<Output = T>> Future for UntilEmulatorCloses<'_, F> {
+    type Output = Option<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if !self.emulator.is_open() {
-            return Poll::Ready(());
+            return Poll::Ready(None);
         }
         self.emulator.update();
         // SAFETY: We are simply projecting the Pin.
-        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().future).poll(cx) }
+        unsafe {
+            Pin::new_unchecked(&mut self.get_unchecked_mut().future)
+                .poll(cx)
+                .map(Some)
+        }
     }
 }
 

--- a/src/emulator/gcn/mod.rs
+++ b/src/emulator/gcn/mod.rs
@@ -123,7 +123,7 @@ impl Emulator {
     /// Checks if a memory reading operation would exceed the memory bounds of the emulated system.
     ///
     /// Returns `true` if the read operation can be performed safely, `false` otherwise.
-    fn check_bounds<T>(&self, offset: u32) -> bool {
+    const fn check_bounds<T>(&self, offset: u32) -> bool {
         match offset {
             (0x80000000..=0x817FFFFF) => offset + size_of::<T>() as u32 <= 0x81800000,
             _ => false,

--- a/src/emulator/genesis/mod.rs
+++ b/src/emulator/genesis/mod.rs
@@ -136,7 +136,7 @@ impl Emulator {
     /// Checks if a memory reading operation would exceed the memory bounds of the emulated system.
     ///
     /// Returns `true` if the read operation can be performed safely, `false` otherwise.
-    fn check_bounds<T>(&self, offset: u32) -> bool {
+    const fn check_bounds<T>(&self, offset: u32) -> bool {
         match offset {
             (0..=0xFFFF) => offset + size_of::<T>() as u32 <= 0x10000,
             _ => false,

--- a/src/emulator/genesis/mod.rs
+++ b/src/emulator/genesis/mod.rs
@@ -214,16 +214,20 @@ pub struct UntilEmulatorCloses<'a, F> {
     future: F,
 }
 
-impl<F: Future<Output = ()>> Future for UntilEmulatorCloses<'_, F> {
-    type Output = ();
+impl<T, F: Future<Output = T>> Future for UntilEmulatorCloses<'_, F> {
+    type Output = Option<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if !self.emulator.process.is_open() {
-            return Poll::Ready(());
+        if !self.emulator.is_open() {
+            return Poll::Ready(None);
         }
         self.emulator.update();
         // SAFETY: We are simply projecting the Pin.
-        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().future).poll(cx) }
+        unsafe {
+            Pin::new_unchecked(&mut self.get_unchecked_mut().future)
+                .poll(cx)
+                .map(Some)
+        }
     }
 }
 

--- a/src/emulator/genesis/mod.rs
+++ b/src/emulator/genesis/mod.rs
@@ -3,7 +3,7 @@
 use core::{
     cell::Cell,
     future::Future,
-    mem::{self, size_of, MaybeUninit},
+    mem::{size_of, MaybeUninit},
     pin::Pin,
     slice,
     task::{Context, Poll},

--- a/src/emulator/genesis/mod.rs
+++ b/src/emulator/genesis/mod.rs
@@ -3,8 +3,9 @@
 use core::{
     cell::Cell,
     future::Future,
-    mem,
+    mem::{self, size_of, MaybeUninit},
     pin::Pin,
+    slice,
     task::{Context, Poll},
 };
 
@@ -122,21 +123,24 @@ impl Emulator {
         }
     }
 
-    /// Reads raw data from the emulated RAM ignoring all endianness settings
-    /// The same call, performed on two different emulators, can be different
-    /// due to the endianness used by the emulator.
+    /// Converts a SEGA Genesis memory address to a real memory address in the emulator process' virtual memory space
     ///
-    /// The offset provided must not be higher than `0xFFFF`, otherwise this
-    /// method will immediately return `Err()`.
-    ///
-    /// This call is meant to be used by experienced users.
-    pub fn read_ignoring_endianness<T: CheckedBitPattern>(&self, offset: u32) -> Result<T, Error> {
-        if offset > 0xFFFF {
-            return Err(Error {});
+    /// The offset provided must not be higher than `0xFFFF`
+    pub fn get_address(&self, offset: u32) -> Result<Address, Error> {
+        match offset {
+            (0..=0xFFFF) => Ok(self.wram_base.get().ok_or(Error {})? + offset),
+            _ => Err(Error {}),
         }
+    }
 
-        let wram = self.wram_base.get().ok_or(Error {})?;
-        self.process.read(wram + offset)
+    /// Checks if a memory reading operation would exceed the memory bounds of the emulated system.
+    ///
+    /// Returns `true` if the read operation can be performed safely, `false` otherwise.
+    fn check_bounds<T>(&self, offset: u32) -> bool {
+        match offset {
+            (0..=0xFFFF) => offset + size_of::<T>() as u32 <= 0x10000,
+            _ => false,
+        }
     }
 
     /// Reads any value from the emulated RAM.
@@ -148,20 +152,79 @@ impl Emulator {
     /// The offset provided must not be higher than `0xFFFF`, otherwise this
     /// method will immediately return `Err()`.
     pub fn read<T: CheckedBitPattern + FromEndian>(&self, offset: u32) -> Result<T, Error> {
-        if (offset > 0xFFFF && offset < 0xFF0000) || offset > 0xFFFFFF {
+        if !self.check_bounds::<T>(offset) {
             return Err(Error {});
         }
 
-        let wram = self.wram_base.get().ok_or(Error {})?;
-
-        let mut end_offset = offset.checked_sub(0xFF0000).unwrap_or(offset);
+        let aligned_offset = offset & !1;
+        let Ok(address) = self.get_address(aligned_offset) else {
+            return Err(Error {});
+        };
         let endian = self.endian.get();
 
-        let toggle = endian == Endian::Little && mem::size_of::<T>() == 1;
-        end_offset ^= toggle as u32;
+        #[derive(Copy, Clone)]
+        #[repr(packed)]
+        struct MaybePadded<T> {
+            _before: MaybeUninit<u8>,
+            value: MaybeUninit<T>,
+            _after: MaybeUninit<u8>,
+        }
 
-        let value = self.process.read::<T>(wram + end_offset)?;
-        Ok(value.from_endian(endian))
+        let misalignment = offset as usize & 1;
+        let mut padded_value = MaybeUninit::<MaybePadded<T>>::uninit();
+
+        // We always want to read a multiple of 2 bytes, so at the end we need
+        // to find the next multiple of 2 bytes for T. However because we maybe
+        // are misaligned, we need to also take that misalignment in the
+        // opposite direction into account before finding the next multiple of
+        // two as otherwise we may not read all of T. This would otherwise go
+        // wrong when e.g. reading a u16 at a misaligned offset. We would start
+        // at the padding byte before the u16, but if we only read 2 bytes, we
+        // then would miss the half of the u16. So adding the misalignment of 1
+        // on top and then rounding up to the next multiple of 2 bytes leaves us
+        // with 4 bytes to read, which we can then nicely swap.
+        let buf = unsafe {
+            slice::from_raw_parts_mut(
+                padded_value.as_mut_ptr().byte_add(misalignment ^ 1) as *mut MaybeUninit<u8>,
+                (size_of::<T>() + misalignment).next_multiple_of(2),
+            )
+        };
+
+        let buf = self.process.read_into_uninit_buf(address, buf)?;
+
+        if endian.eq(&Endian::Little) {
+            buf.chunks_exact_mut(2).for_each(|chunk| chunk.swap(0, 1));
+        }
+
+        unsafe {
+            let value = padded_value.assume_init_ref().value;
+            if !T::is_valid_bit_pattern(&*value.as_ptr().cast::<T::Bits>()) {
+                return Err(Error {});
+            }
+
+            Ok(value.assume_init().from_be())
+        }
+    }
+
+    /// Follows a path of pointers from the address given and reads a value of the type specified from
+    /// the process at the end of the pointer path.
+    pub fn read_pointer_path<T: CheckedBitPattern + FromEndian>(
+        &self,
+        base_address: u32,
+        path: &[u32],
+    ) -> Result<T, Error> {
+        self.read(self.deref_offsets(base_address, path)?)
+    }
+
+    /// Follows a path of pointers from the address given and returns the address at the end
+    /// of the pointer path
+    fn deref_offsets(&self, base_address: u32, path: &[u32]) -> Result<u32, Error> {
+        let mut address = base_address;
+        let (&last, path) = path.split_last().ok_or(Error {})?;
+        for &offset in path {
+            address = self.read::<u32>(address + offset)?;
+        }
+        Ok(address + last)
     }
 }
 

--- a/src/emulator/genesis/mod.rs
+++ b/src/emulator/genesis/mod.rs
@@ -205,27 +205,6 @@ impl Emulator {
             Ok(value.assume_init().from_be())
         }
     }
-
-    /// Follows a path of pointers from the address given and reads a value of the type specified from
-    /// the process at the end of the pointer path.
-    pub fn read_pointer_path<T: CheckedBitPattern + FromEndian>(
-        &self,
-        base_address: u32,
-        path: &[u32],
-    ) -> Result<T, Error> {
-        self.read(self.deref_offsets(base_address, path)?)
-    }
-
-    /// Follows a path of pointers from the address given and returns the address at the end
-    /// of the pointer path
-    fn deref_offsets(&self, base_address: u32, path: &[u32]) -> Result<u32, Error> {
-        let mut address = base_address;
-        let (&last, path) = path.split_last().ok_or(Error {})?;
-        for &offset in path {
-            address = self.read::<u32>(address + offset)?;
-        }
-        Ok(address + last)
-    }
 }
 
 /// A future that executes a future until the emulator closes.

--- a/src/emulator/ps1/mod.rs
+++ b/src/emulator/ps1/mod.rs
@@ -198,16 +198,20 @@ pub struct UntilEmulatorCloses<'a, F> {
     future: F,
 }
 
-impl<F: Future<Output = ()>> Future for UntilEmulatorCloses<'_, F> {
-    type Output = ();
+impl<T, F: Future<Output = T>> Future for UntilEmulatorCloses<'_, F> {
+    type Output = Option<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if !self.emulator.is_open() {
-            return Poll::Ready(());
+            return Poll::Ready(None);
         }
         self.emulator.update();
         // SAFETY: We are simply projecting the Pin.
-        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().future).poll(cx) }
+        unsafe {
+            Pin::new_unchecked(&mut self.get_unchecked_mut().future)
+                .poll(cx)
+                .map(Some)
+        }
     }
 }
 

--- a/src/emulator/ps1/mod.rs
+++ b/src/emulator/ps1/mod.rs
@@ -3,8 +3,10 @@
 use core::{
     cell::Cell,
     future::Future,
+    mem::size_of,
+    ops::Sub,
     pin::Pin,
-    task::{Context, Poll}, ops::Sub, mem::size_of,
+    task::{Context, Poll},
 };
 
 use crate::{future::retry, Address, Error, Process};
@@ -131,7 +133,9 @@ impl Emulator {
     /// Valid addresses for the PS1 range from `0x80000000` to `0x817FFFFF`.
     pub fn get_address(&self, offset: u32) -> Result<Address, Error> {
         match offset {
-            (0x80000000..=0x817FFFFF) => Ok(self.ram_base.get().ok_or(Error {})? + offset.sub(0x80000000)),
+            (0x80000000..=0x817FFFFF) => {
+                Ok(self.ram_base.get().ok_or(Error {})? + offset.sub(0x80000000))
+            }
             _ => Err(Error {}),
         }
     }
@@ -155,7 +159,7 @@ impl Emulator {
     /// The offset provided is meant to be the same memory address as usually
     /// mapped on the original hardware. Valid addresses range from `0x80000000`
     /// to `0x817FFFFF`.
-    /// 
+    ///
     /// Providing any offset outside the range of the PS1's RAM will return
     /// `Err()`.
     pub fn read<T: CheckedBitPattern>(&self, offset: u32) -> Result<T, Error> {

--- a/src/emulator/ps1/mod.rs
+++ b/src/emulator/ps1/mod.rs
@@ -4,7 +4,7 @@ use core::{
     cell::Cell,
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{Context, Poll}, ops::Sub, mem::size_of,
 };
 
 use crate::{future::retry, Address, Error, Process};
@@ -126,27 +126,64 @@ impl Emulator {
         }
     }
 
+    /// Converts a PS1 memory address to a real memory address in the emulator process' virtual memory space
+    ///
+    /// Valid addresses for the PS1 range from `0x80000000` to `0x817FFFFF`.
+    pub fn get_address(&self, offset: u32) -> Result<Address, Error> {
+        match offset {
+            (0x80000000..=0x817FFFFF) => Ok(self.ram_base.get().ok_or(Error {})? + offset.sub(0x80000000)),
+            _ => Err(Error {}),
+        }
+    }
+
+    /// Checks if a memory reading operation would exceed the memory bounds of the emulated system.
+    ///
+    /// Returns `true` if the read operation can be performed safely, `false` otherwise.
+    fn check_bounds<T>(&self, offset: u32) -> bool {
+        match offset {
+            (0x80000000..=0x817FFFFF) => offset + size_of::<T>() as u32 <= 0x81800000,
+            _ => false,
+        }
+    }
+
     /// Reads any value from the emulated RAM.
     ///
     /// In PS1, memory addresses are usually mapped at fixed locations starting
     /// from `0x80000000`, and is the way many emulators, as well as the
     /// GameShark on original hardware, access memory.
     ///
-    /// For this reason, this method will automatically convert offsets provided
-    /// in such format. For example, providing an offset of `0x1234` or
-    /// `0x80001234` will return the same value.
-    ///
+    /// The offset provided is meant to be the same memory address as usually
+    /// mapped on the original hardware. Valid addresses range from `0x80000000`
+    /// to `0x817FFFFF`.
+    /// 
     /// Providing any offset outside the range of the PS1's RAM will return
     /// `Err()`.
     pub fn read<T: CheckedBitPattern>(&self, offset: u32) -> Result<T, Error> {
-        if (offset > 0x1FFFFF && offset < 0x80000000) || offset > 0x801FFFFF {
-            return Err(Error {});
-        };
+        match self.check_bounds::<T>(offset) {
+            true => self.process.read(self.get_address(offset)?),
+            false => Err(Error {}),
+        }
+    }
 
-        let ram_base = self.ram_base.get().ok_or(Error {})?;
-        let end_offset = offset.checked_sub(0x80000000).unwrap_or(offset);
+    /// Follows a path of pointers from the address given and reads a value of the type specified from
+    /// the process at the end of the pointer path.
+    pub fn read_pointer_path<T: CheckedBitPattern>(
+        &self,
+        base_address: u32,
+        path: &[u32],
+    ) -> Result<T, Error> {
+        self.read(self.deref_offsets(base_address, path)?)
+    }
 
-        self.process.read(ram_base + end_offset)
+    /// Follows a path of pointers from the address given and returns the address at the end
+    /// of the pointer path
+    fn deref_offsets(&self, base_address: u32, path: &[u32]) -> Result<u32, Error> {
+        let mut address = base_address;
+        let (&last, path) = path.split_last().ok_or(Error {})?;
+        for &offset in path {
+            address = self.read::<u32>(address + offset)?;
+        }
+        Ok(address + last)
     }
 }
 

--- a/src/emulator/ps1/mod.rs
+++ b/src/emulator/ps1/mod.rs
@@ -143,7 +143,7 @@ impl Emulator {
     /// Checks if a memory reading operation would exceed the memory bounds of the emulated system.
     ///
     /// Returns `true` if the read operation can be performed safely, `false` otherwise.
-    fn check_bounds<T>(&self, offset: u32) -> bool {
+    const fn check_bounds<T>(&self, offset: u32) -> bool {
         match offset {
             (0x80000000..=0x817FFFFF) => offset + size_of::<T>() as u32 <= 0x81800000,
             _ => false,

--- a/src/emulator/ps2/mod.rs
+++ b/src/emulator/ps2/mod.rs
@@ -3,8 +3,10 @@
 use core::{
     cell::Cell,
     future::Future,
+    mem::size_of,
+    ops::Sub,
     pin::Pin,
-    task::{Context, Poll}, ops::Sub, mem::size_of,
+    task::{Context, Poll},
 };
 
 use crate::{future::retry, Address, Error, Process};
@@ -106,7 +108,9 @@ impl Emulator {
     /// Valid addresses for the PS2 range from `0x00100000` to `0x01FFFFFF`.
     pub fn get_address(&self, offset: u32) -> Result<Address, Error> {
         match offset {
-            (0x00100000..=0x01FFFFFF) => Ok(self.ram_base.get().ok_or(Error {})? + offset.sub(0x00100000)),
+            (0x00100000..=0x01FFFFFF) => {
+                Ok(self.ram_base.get().ok_or(Error {})? + offset.sub(0x00100000))
+            }
             _ => Err(Error {}),
         }
     }

--- a/src/emulator/ps2/mod.rs
+++ b/src/emulator/ps2/mod.rs
@@ -118,7 +118,7 @@ impl Emulator {
     /// Checks if a memory reading operation would exceed the memory bounds of the emulated system.
     ///
     /// Returns `true` if the read operation can be performed safely, `false` otherwise.
-    fn check_bounds<T>(&self, offset: u32) -> bool {
+    const fn check_bounds<T>(&self, offset: u32) -> bool {
         match offset {
             (0x00100000..=0x01FFFFFF) => offset + size_of::<T>() as u32 <= 0x02000000,
             _ => false,

--- a/src/emulator/ps2/mod.rs
+++ b/src/emulator/ps2/mod.rs
@@ -171,16 +171,20 @@ pub struct UntilEmulatorCloses<'a, F> {
     future: F,
 }
 
-impl<F: Future<Output = ()>> Future for UntilEmulatorCloses<'_, F> {
-    type Output = ();
+impl<T, F: Future<Output = T>> Future for UntilEmulatorCloses<'_, F> {
+    type Output = Option<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if !self.emulator.is_open() {
-            return Poll::Ready(());
+            return Poll::Ready(None);
         }
         self.emulator.update();
         // SAFETY: We are simply projecting the Pin.
-        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().future).poll(cx) }
+        unsafe {
+            Pin::new_unchecked(&mut self.get_unchecked_mut().future)
+                .poll(cx)
+                .map(Some)
+        }
     }
 }
 

--- a/src/emulator/sms/mod.rs
+++ b/src/emulator/sms/mod.rs
@@ -3,8 +3,10 @@
 use core::{
     cell::Cell,
     future::Future,
+    mem::size_of,
+    ops::Sub,
     pin::Pin,
-    task::{Context, Poll}, mem::size_of, ops::Sub,
+    task::{Context, Poll},
 };
 
 use crate::{future::retry, Address, Error, Process};

--- a/src/emulator/sms/mod.rs
+++ b/src/emulator/sms/mod.rs
@@ -124,7 +124,7 @@ impl Emulator {
     /// Checks if a memory reading operation would exceed the memory bounds of the emulated system.
     ///
     /// Returns `true` if the read operation can be performed safely, `false` otherwise.
-    fn check_bounds<T>(&self, offset: u32) -> bool {
+    const fn check_bounds<T>(&self, offset: u32) -> bool {
         match offset {
             (0xC000..=0xDFFF) => offset + size_of::<T>() as u32 <= 0xE000,
             _ => false,

--- a/src/emulator/wii/mod.rs
+++ b/src/emulator/wii/mod.rs
@@ -130,7 +130,7 @@ impl Emulator {
     /// Checks if a memory reading operation would exceed the memory bounds of the emulated system.
     ///
     /// Returns `true` if the read operation can be performed safely, `false` otherwise.
-    fn check_bounds<T>(&self, offset: u32) -> bool {
+    const fn check_bounds<T>(&self, offset: u32) -> bool {
         match offset {
             (0x80000000..=0x817FFFFF) => offset + size_of::<T>() as u32 <= 0x81800000,
             (0x90000000..=0x93FFFFFF) => offset + size_of::<T>() as u32 <= 0x94000000,

--- a/src/emulator/wii/mod.rs
+++ b/src/emulator/wii/mod.rs
@@ -206,16 +206,20 @@ pub struct UntilEmulatorCloses<'a, F> {
     future: F,
 }
 
-impl<F: Future<Output = ()>> Future for UntilEmulatorCloses<'_, F> {
-    type Output = ();
+impl<T, F: Future<Output = T>> Future for UntilEmulatorCloses<'_, F> {
+    type Output = Option<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if !self.emulator.is_open() {
-            return Poll::Ready(());
+            return Poll::Ready(None);
         }
         self.emulator.update();
         // SAFETY: We are simply projecting the Pin.
-        unsafe { Pin::new_unchecked(&mut self.get_unchecked_mut().future).poll(cx) }
+        unsafe {
+            Pin::new_unchecked(&mut self.get_unchecked_mut().future)
+                .poll(cx)
+                .map(Some)
+        }
     }
 }
 


### PR DESCRIPTION
This commit tweaks the logic inside the emulator modules in order to let have have a uniform naming scheme for their functions.

Each emulator module will now have the following functions:
- `get_address() -> Address`: can be used at any point in an autosplitter to convert a game system's physical memory address to the corresponding memory address in the emulator process' virtual memory space
- `check_bounds() -> bool`: will check if a memory reading operation does not exceed the memory bounds of the emulated system
- `read::<T>`: As before, allows to read any value from the emulated RAM
- `read_pointer_path::<T>`: valid only for 32bit systems and above, allows to resolve pointer paths

Additionally, the specific commit for Genesis emulators also fixes https://github.com/LiveSplit/asr/issues/86