### PR TITLE
Unity / Mono V1 with cattrs

### DIFF
--- a/src/game_engine/unity/mono.rs
+++ b/src/game_engine/unity/mono.rs
@@ -228,6 +228,12 @@ impl Assembly {
             .ok()
             .filter(|val| !val.is_null())?;
         let offsets = MonoClassOffsets::new(module.version, module.pointer_size)?;
+        let table_addr = process.read_pointer(image + module.offsets.monoimage_class_cache + module.offsets.monointernalhashtable_table, module.pointer_size).ok()?;
+        let table = process.read_pointer(table_addr, module.pointer_size).ok()?;
+        let class = process.read_pointer(table, module.pointer_size).ok()?;
+        if process.read_pointer(class + offsets.monoclassdef_klass + offsets.monoclass_image, module.pointer_size).is_ok_and(|a| a == image) {
+            return Some(Image { image, offsets });
+        }
         Some(Image {
             image,
             offsets,

--- a/src/game_engine/unity/mono.rs
+++ b/src/game_engine/unity/mono.rs
@@ -829,7 +829,7 @@ struct MonoClassOffsets {
     monoclass_name_space: u8,
     monoclass_fields: u8,
     monoclassdef_field_count: u16,
-    monoclass_runtime_info: u8,
+    monoclass_runtime_info: u16,
     monoclass_vtable_size: u8,
     monoclass_parent: u8,
 }
@@ -923,6 +923,18 @@ impl MonoClassOffsets {
     const fn new(version: Version, pointer_size: PointerSize, cattrs: bool) -> Option<&'static Self> {
         match pointer_size {
             PointerSize::Bit64 => match version {
+                Version::V1 if cattrs => Some(&Self {
+                    monoclassdef_next_class_cache: 0x108,
+                    monoclassdef_klass: 0x0,
+                    monoclass_image: 0x48,
+                    monoclass_name: 0x50,
+                    monoclass_name_space: 0x58,
+                    monoclass_fields: 0xB0,
+                    monoclassdef_field_count: 0x9C,
+                    monoclass_runtime_info: 0x100,
+                    monoclass_vtable_size: 0x18, // MonoVtable.data
+                    monoclass_parent: 0x30,
+                }),
                 Version::V1 => Some(&Self {
                     monoclassdef_next_class_cache: 0x100,
                     monoclassdef_klass: 0x0,

--- a/src/game_engine/unity/mono.rs
+++ b/src/game_engine/unity/mono.rs
@@ -812,6 +812,7 @@ struct MonoAssemblyOffsets {
 struct MonoClassOffsets {
     monoclassdef_next_class_cache: u16,
     monoclassdef_klass: u8,
+    monoclass_image: u8,
     monoclass_name: u8,
     monoclass_name_space: u8,
     monoclass_fields: u8,
@@ -913,6 +914,7 @@ impl MonoClassOffsets {
                 Version::V1 => Some(&Self {
                     monoclassdef_next_class_cache: 0x100,
                     monoclassdef_klass: 0x0,
+                    monoclass_image: 0x40,
                     monoclass_name: 0x48,
                     monoclass_name_space: 0x50,
                     monoclass_fields: 0xA8,
@@ -924,6 +926,7 @@ impl MonoClassOffsets {
                 Version::V2 => Some(&Self {
                     monoclassdef_next_class_cache: 0x108,
                     monoclassdef_klass: 0x0,
+                    monoclass_image: 0x40,
                     monoclass_name: 0x48,
                     monoclass_name_space: 0x50,
                     monoclass_fields: 0x98,
@@ -935,6 +938,7 @@ impl MonoClassOffsets {
                 Version::V3 => Some(&Self {
                     monoclassdef_next_class_cache: 0x108,
                     monoclassdef_klass: 0x0,
+                    monoclass_image: 0x40,
                     monoclass_name: 0x48,
                     monoclass_name_space: 0x50,
                     monoclass_fields: 0x98,
@@ -948,6 +952,7 @@ impl MonoClassOffsets {
                 Version::V1 => Some(&Self {
                     monoclassdef_next_class_cache: 0xA8,
                     monoclassdef_klass: 0x0,
+                    monoclass_image: 0x2C,
                     monoclass_name: 0x30,
                     monoclass_name_space: 0x34,
                     monoclass_fields: 0x74,
@@ -959,6 +964,7 @@ impl MonoClassOffsets {
                 Version::V2 => Some(&Self {
                     monoclassdef_next_class_cache: 0xA8,
                     monoclassdef_klass: 0x0,
+                    monoclass_image: 0x28,
                     monoclass_name: 0x2C,
                     monoclass_name_space: 0x30,
                     monoclass_fields: 0x60,
@@ -970,6 +976,7 @@ impl MonoClassOffsets {
                 Version::V3 => Some(&Self {
                     monoclassdef_next_class_cache: 0xA0,
                     monoclassdef_klass: 0x0,
+                    monoclass_image: 0x28,
                     monoclass_name: 0x2C,
                     monoclass_name_space: 0x30,
                     monoclass_fields: 0x60,


### PR DESCRIPTION
There are 2 sets of `monoclass` offsets possible within `V1`: without `cattrs` and with `cattrs`.

This looks at the `monoclass_image` to see if it points back to the `image` that the class came from, to decide which of those sets of offsets to use.