### PR TITLE
Add `#[must_use]` to All Custom Futures

### DIFF
--- a/src/emulator/gba/mod.rs
+++ b/src/emulator/gba/mod.rs
@@ -180,6 +180,7 @@ impl Emulator {
 }
 
 /// A future that executes a future until the emulator closes.
+#[must_use = "You need to await this future."]
 pub struct UntilEmulatorCloses<'a, F> {
     emulator: &'a Emulator,
     future: F,

--- a/src/emulator/gcn/mod.rs
+++ b/src/emulator/gcn/mod.rs
@@ -150,6 +150,7 @@ impl Emulator {
 }
 
 /// A future that executes a future until the emulator closes.
+#[must_use = "You need to await this future."]
 pub struct UntilEmulatorCloses<'a, F> {
     emulator: &'a Emulator,
     future: F,

--- a/src/emulator/genesis/mod.rs
+++ b/src/emulator/genesis/mod.rs
@@ -166,6 +166,7 @@ impl Emulator {
 }
 
 /// A future that executes a future until the emulator closes.
+#[must_use = "You need to await this future."]
 pub struct UntilEmulatorCloses<'a, F> {
     emulator: &'a Emulator,
     future: F,

--- a/src/emulator/ps1/mod.rs
+++ b/src/emulator/ps1/mod.rs
@@ -151,6 +151,7 @@ impl Emulator {
 }
 
 /// A future that executes a future until the emulator closes.
+#[must_use = "You need to await this future."]
 pub struct UntilEmulatorCloses<'a, F> {
     emulator: &'a Emulator,
     future: F,

--- a/src/emulator/ps2/mod.rs
+++ b/src/emulator/ps2/mod.rs
@@ -146,6 +146,7 @@ impl Emulator {
 }
 
 /// A future that executes a future until the emulator closes.
+#[must_use = "You need to await this future."]
 pub struct UntilEmulatorCloses<'a, F> {
     emulator: &'a Emulator,
     future: F,

--- a/src/emulator/sms/mod.rs
+++ b/src/emulator/sms/mod.rs
@@ -130,6 +130,7 @@ impl Emulator {
 }
 
 /// A future that executes a future until the emulator closes.
+#[must_use = "You need to await this future."]
 pub struct UntilEmulatorCloses<'a, F> {
     emulator: &'a Emulator,
     future: F,

--- a/src/emulator/wii/mod.rs
+++ b/src/emulator/wii/mod.rs
@@ -231,6 +231,7 @@ impl Emulator {
 }
 
 /// A future that executes a future until the emulator closes.
+#[must_use = "You need to await this future."]
 pub struct UntilEmulatorCloses<'a, F> {
     emulator: &'a Emulator,
     future: F,

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -271,6 +271,7 @@ impl<const N: usize> Signature<N> {
 }
 
 /// A future that executes a future until the process closes.
+#[must_use = "You need to await this future."]
 pub struct UntilProcessCloses<'a, F> {
     process: &'a Process,
     future: F,

--- a/src/future/time.rs
+++ b/src/future/time.rs
@@ -115,6 +115,7 @@ pub fn sleep(duration: Duration) -> Sleep {
 ///   // the future timed out
 /// }
 /// ```
+#[must_use = "You need to await this future."]
 pub struct Timeout<F> {
     sleep: Sleep,
     future: F,


### PR DESCRIPTION
Without this it's very easy to forget awaiting the futures, leading to possibly long debugging sessions.