### PR TITLE
get_array_string: len <= N

### DIFF
--- a/src/runtime/settings/value.rs
+++ b/src/runtime/settings/value.rs
@@ -271,7 +271,7 @@ impl Value {
             let mut len = N;
             let success =
                 sys::setting_value_get_string(self.0, buf.as_bytes_mut().as_mut_ptr(), &mut len);
-            if !success {
+            if !(success && len <= N) {
                 return if len == 0 { None } else { Some(Err(Error {})) };
             }
             buf.set_len(len);


### PR DESCRIPTION
When I tried to use `get_array_string` with `N` = `128`, on a settings string of length `591`, somehow it errored because `sys::setting_value_get_string` produced success `true` and set `len` to `1919512659`, causing `buf.set_len(len)` to panic because `len` was was not less than or equal to `N`.

Adding an extra `len <= N` check fixes this error.