### PR TITLE
Updated PS1 sigscans

### DIFF
--- a/src/emulator/ps1/duckstation.rs
+++ b/src/emulator/ps1/duckstation.rs
@@ -34,16 +34,12 @@ impl State {
                 .and_then(|addr| Some(addr + 0x4 + game.read::<i32>(addr).ok()?))?;
         }
 
-        Some(game.read::<Address64>(self.addr).ok()?.into())
+        Some(game.read::<Address64>(self.addr).unwrap_or_default().into())
     }
 
     pub fn keep_alive(&self, game: &Process, wram_base: &mut Option<Address>) -> bool {
-        if let Ok(addr) = game.read::<Address64>(self.addr) {
-            *wram_base = Some(addr.into());
-            true
-        } else {
-            false
-        }
+        *wram_base = Some(game.read::<Address64>(self.addr).unwrap_or_default().into());
+        true
     }
 
     pub const fn new() -> Self {

--- a/src/emulator/ps1/epsxe.rs
+++ b/src/emulator/ps1/epsxe.rs
@@ -12,9 +12,10 @@ impl State {
             .filter(|(_, state)| matches!(state, super::State::Epsxe(_)))
             .find_map(|(name, _)| game.get_module_range(name).ok())?;
 
-        let ptr = SIG.scan_process_range(game, main_module_range)? + 5;
-
-        Some(game.read::<Address32>(ptr).ok()?.into())
+        SIG.scan_process_range(game, main_module_range)
+            .map(|val| val + 5)
+            .and_then(|addr| game.read::<Address32>(addr).ok())
+            .map(|val| val.into())
     }
 
     pub const fn keep_alive(&self) -> bool {

--- a/src/emulator/ps1/mod.rs
+++ b/src/emulator/ps1/mod.rs
@@ -132,10 +132,14 @@ impl Emulator {
     ///
     /// Valid addresses for the PS1 range from `0x80000000` to `0x817FFFFF`.
     pub fn get_address(&self, offset: u32) -> Result<Address, Error> {
+        let addr = self
+            .ram_base
+            .get()
+            .filter(|addr| !addr.is_null())
+            .ok_or(Error {})?;
+
         match offset {
-            (0x80000000..=0x817FFFFF) => {
-                Ok(self.ram_base.get().ok_or(Error {})? + offset.sub(0x80000000))
-            }
+            (0x80000000..=0x817FFFFF) => Ok(addr + offset.sub(0x80000000)),
             _ => Err(Error {}),
         }
     }

--- a/src/emulator/ps1/mod.rs
+++ b/src/emulator/ps1/mod.rs
@@ -112,7 +112,7 @@ impl Emulator {
             State::PsxFin(x) => x.keep_alive(),
             State::Duckstation(x) => x.keep_alive(&self.process, &mut ram_base),
             State::Retroarch(x) => x.keep_alive(&self.process),
-            State::PcsxRedux(x) => x.keep_alive(&self.process),
+            State::PcsxRedux(x) => x.keep_alive(&self.process, &mut ram_base),
             State::Xebra(x) => x.keep_alive(),
             State::Mednafen(x) => x.keep_alive(),
         };

--- a/src/emulator/ps1/pcsx_redux.rs
+++ b/src/emulator/ps1/pcsx_redux.rs
@@ -1,12 +1,9 @@
-use crate::{
-    file_format::pe, signature::Signature, Address, Address32, Address64, MemoryRangeFlags, Process,
-};
+use crate::{file_format::pe, signature::Signature, Address, Address64, PointerSize, Process};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct State {
-    is_64_bit: bool,
     addr_base: Address,
-    addr: Address,
+    offsets: Option<[u64; 3]>,
 }
 
 impl State {
@@ -16,58 +13,57 @@ impl State {
             .filter(|(_, state)| matches!(state, super::State::PcsxRedux(_)))
             .find_map(|(name, _)| game.get_module_range(name).ok())?;
 
-        self.is_64_bit =
-            pe::MachineType::read(game, main_module_range.0) == Some(pe::MachineType::X86_64);
-
-        if self.is_64_bit {
-            const SIG_BASE: Signature<25> = Signature::new(
-                "48 B9 ?? ?? ?? ?? ?? ?? ?? ?? E8 ?? ?? ?? ?? C7 85 ?? ?? ?? ?? 00 00 00 00",
-            );
-            const SIG_OFFSET: Signature<9> = Signature::new("89 D1 C1 E9 10 48 8B ?? ??");
-
-            self.addr_base = SIG_BASE.scan_process_range(game, main_module_range)? + 2;
-            self.addr = game.read::<Address64>(self.addr_base).ok()?.into();
-
-            let offset = SIG_OFFSET.scan_process_range(game, main_module_range)? + 8;
-            let offset = game.read::<u8>(offset).ok()? as u64;
-
-            let addr = game.read::<Address64>(self.addr + offset).ok()?;
-
-            Some(game.read::<Address64>(addr).ok()?.into())
-        } else {
-            const SIG: Signature<18> =
-                Signature::new("8B 3D 20 ?? ?? ?? 0F B7 D3 8B 04 95 ?? ?? ?? ?? 21 05");
-
-            self.addr_base = game
-                .memory_ranges()
-                .filter(|m| {
-                    m.flags()
-                        .unwrap_or_default()
-                        .contains(MemoryRangeFlags::WRITE)
-                })
-                .find_map(|m| SIG.scan_process_range(game, m.range().ok()?))?
-                + 2;
-
-            self.addr = game.read::<Address32>(self.addr_base).ok()?.into();
-            Some(self.addr)
+        if pe::MachineType::read(game, main_module_range.0)?.pointer_size()? != PointerSize::Bit64 {
+            return None;
         }
+
+        const SIG_BASE: Signature<14> = Signature::new("48 8B 0D ?? ?? ?? ?? ?? ?? ?? FF FF FF 00");
+        const SIG_OFFSET: Signature<10> = Signature::new("4C 8B 99 ?? ?? ?? ?? 4D 8B 7B");
+
+        self.addr_base = SIG_BASE
+            .scan_process_range(game, main_module_range)
+            .map(|val| val + 3)
+            .and_then(|addr| Some(addr + 0x4 + game.read::<i32>(addr).ok()?))?;
+
+        let p_addr = SIG_OFFSET.scan_process_range(game, main_module_range)?;
+        self.offsets = Some([
+            0,
+            game.read::<i32>(p_addr + 3).ok()? as u64,
+            game.read::<u8>(p_addr + 10).ok()?.into(),
+        ]);
+
+        game.read_pointer_path::<Address64>(
+            self.addr_base,
+            PointerSize::Bit64,
+            &self.offsets.unwrap(),
+        )
+        .map(|val| val.into())
+        .ok()
     }
 
-    pub fn keep_alive(&self, game: &Process) -> bool {
-        if self.is_64_bit {
-            game.read::<Address64>(self.addr_base)
-                .is_ok_and(|addr| self.addr == addr.into())
-        } else {
-            game.read::<Address32>(self.addr_base)
-                .is_ok_and(|addr| self.addr == addr.into())
+    pub fn keep_alive(&self, game: &Process, ram_base: &mut Option<Address>) -> bool {
+        match self.offsets {
+            None => false,
+            Some(offsets) => {
+                match game.read_pointer_path::<Address64>(
+                    self.addr_base,
+                    PointerSize::Bit64,
+                    &offsets,
+                ) {
+                    Ok(result) => {
+                        *ram_base = Some(result.into());
+                        true
+                    }
+                    Err(_) => false,
+                }
+            }
         }
     }
 
     pub const fn new() -> Self {
         Self {
-            is_64_bit: true,
             addr_base: Address::NULL,
-            addr: Address::NULL,
+            offsets: None,
         }
     }
 }

--- a/src/emulator/ps1/pcsx_redux.rs
+++ b/src/emulator/ps1/pcsx_redux.rs
@@ -30,23 +30,20 @@ impl State {
             game.read::<u8>(addr + 14).ok()?.into(),
         ];
 
-        game.read_pointer_path::<Address64>(self.addr_base, PointerSize::Bit64, &self.offsets)
-            .map(|val| val.into())
-            .ok()
+        Some(
+            game.read_pointer_path::<Address64>(self.addr_base, PointerSize::Bit64, &self.offsets)
+                .unwrap_or_default()
+                .into(),
+        )
     }
 
     pub fn keep_alive(&self, game: &Process, ram_base: &mut Option<Address>) -> bool {
-        match game
-            .read_pointer_path::<Address64>(self.addr_base, PointerSize::Bit64, &self.offsets)
-            .ok()
-            .filter(|addr| !addr.is_null())
-        {
-            Some(result) => {
-                *ram_base = Some(result.into());
-                true
-            }
-            None => false,
-        }
+        *ram_base = Some(
+            game.read_pointer_path::<Address64>(self.addr_base, PointerSize::Bit64, &self.offsets)
+                .unwrap_or_default()
+                .into(),
+        );
+        true
     }
 
     pub const fn new() -> Self {

--- a/src/emulator/ps1/pcsx_redux.rs
+++ b/src/emulator/ps1/pcsx_redux.rs
@@ -3,7 +3,7 @@ use crate::{file_format::pe, signature::Signature, Address, Address64, PointerSi
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct State {
     addr_base: Address,
-    offsets: Option<[u64; 3]>,
+    offsets: [u64; 3],
 }
 
 impl State {
@@ -17,53 +17,42 @@ impl State {
             return None;
         }
 
-        const SIG_BASE: Signature<14> = Signature::new("48 8B 0D ?? ?? ?? ?? ?? ?? ?? FF FF FF 00");
-        const SIG_OFFSET: Signature<10> = Signature::new("4C 8B 99 ?? ?? ?? ?? 4D 8B 7B");
+        const SIG_BASE: Signature<19> =
+            Signature::new("48 8B 05 ?? ?? ?? ?? 48 8B 80 ?? ?? ?? ?? 48 8B 50 ?? E8");
 
-        self.addr_base = SIG_BASE
-            .scan_process_range(game, main_module_range)
-            .map(|val| val + 3)
-            .and_then(|addr| Some(addr + 0x4 + game.read::<i32>(addr).ok()?))?;
+        let addr = SIG_BASE.scan_process_range(game, main_module_range)? + 3;
 
-        let p_addr = SIG_OFFSET.scan_process_range(game, main_module_range)?;
-        self.offsets = Some([
+        self.addr_base = addr + 0x4 + game.read::<i32>(addr).ok()?;
+
+        self.offsets = [
             0,
-            game.read::<i32>(p_addr + 3).ok()? as u64,
-            game.read::<u8>(p_addr + 10).ok()?.into(),
-        ]);
+            game.read::<i32>(addr + 7).ok()? as u64,
+            game.read::<u8>(addr + 14).ok()?.into(),
+        ];
 
-        game.read_pointer_path::<Address64>(
-            self.addr_base,
-            PointerSize::Bit64,
-            &self.offsets.unwrap(),
-        )
-        .map(|val| val.into())
-        .ok()
+        game.read_pointer_path::<Address64>(self.addr_base, PointerSize::Bit64, &self.offsets)
+            .map(|val| val.into())
+            .ok()
     }
 
     pub fn keep_alive(&self, game: &Process, ram_base: &mut Option<Address>) -> bool {
-        match self.offsets {
-            None => false,
-            Some(offsets) => {
-                match game.read_pointer_path::<Address64>(
-                    self.addr_base,
-                    PointerSize::Bit64,
-                    &offsets,
-                ) {
-                    Ok(result) => {
-                        *ram_base = Some(result.into());
-                        true
-                    }
-                    Err(_) => false,
-                }
+        match game
+            .read_pointer_path::<Address64>(self.addr_base, PointerSize::Bit64, &self.offsets)
+            .ok()
+            .filter(|addr| !addr.is_null())
+        {
+            Some(result) => {
+                *ram_base = Some(result.into());
+                true
             }
+            None => false,
         }
     }
 
     pub const fn new() -> Self {
         Self {
             addr_base: Address::NULL,
-            offsets: None,
+            offsets: [0; 3],
         }
     }
 }

--- a/src/emulator/ps1/retroarch.rs
+++ b/src/emulator/ps1/retroarch.rs
@@ -1,4 +1,6 @@
-use crate::{file_format::pe, signature::Signature, Address, Address32, Address64, Process};
+use crate::{
+    file_format::pe, signature::Signature, Address, Address32, Address64, PointerSize, Process,
+};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct State {
@@ -20,7 +22,7 @@ impl State {
             .find_map(|(name, _)| game.get_module_address(name).ok())?;
 
         let is_64_bit =
-            pe::MachineType::read(game, main_module_address) == Some(pe::MachineType::X86_64);
+            pe::MachineType::read(game, main_module_address)?.pointer_size()? == PointerSize::Bit64;
 
         let (core_name, core_address) = SUPPORTED_CORES
             .iter()
@@ -28,65 +30,79 @@ impl State {
 
         self.core_base = core_address;
 
+        let base_scan = pe::symbols(game, core_address)
+            .find(|symbol| {
+                symbol
+                    .get_name::<22>(game)
+                    .is_ok_and(|name| name.matches(b"retro_get_memory_data"))
+            })?
+            .address;
+
         if core_name == SUPPORTED_CORES[0] || core_name == SUPPORTED_CORES[1] {
             // Mednafen
             if is_64_bit {
-                const SIG: Signature<14> =
-                    Signature::new("48 8B 05 ?? ?? ?? ?? 41 81 E4 FF FF 1F 00");
-                let ptr = SIG.scan_process_range(
-                    game,
-                    (core_address, game.get_module_size(core_name).ok()?),
-                )? + 3;
-                let ptr = ptr + 0x4 + game.read::<i32>(ptr).ok()?;
-                Some(game.read::<Address64>(ptr).ok()?.into())
+                const SIG: Signature<4> = Signature::new("48 0F 44 05");
+                SIG.scan_process_range(game, (base_scan, 0x100))
+                    .map(|addr| addr + 4)
+                    .and_then(|addr| {
+                        game.read::<Address64>(addr + 0x4 + game.read::<i32>(addr).ok()?)
+                            .ok()
+                    })
+                    .map(|addr| addr.into())
             } else {
-                const SIG: Signature<11> = Signature::new("A1 ?? ?? ?? ?? 81 E3 FF FF 1F 00");
-                let ptr = SIG.scan_process_range(
-                    game,
-                    (core_address, game.get_module_size(core_name).ok()?),
-                )? + 1;
-                let ptr = game.read::<Address32>(ptr).ok()?;
-                Some(game.read::<Address32>(ptr).ok()?.into())
+                const SIG: Signature<3> = Signature::new("0F 44 05");
+                SIG.scan_process_range(game, (base_scan, 0x100))
+                    .map(|addr| addr + 3)
+                    .and_then(|addr| {
+                        game.read::<Address32>(game.read::<Address32>(addr).ok()?)
+                            .ok()
+                    })
+                    .map(|addr| addr.into())
             }
         } else if core_name == SUPPORTED_CORES[2] {
             // Swanstation
             if is_64_bit {
-                const SIG: Signature<15> =
-                    Signature::new("48 89 0D ?? ?? ?? ?? 89 35 ?? ?? ?? ?? 89 3D");
-                let addr = SIG.scan_process_range(
-                    game,
-                    (core_address, game.get_module_size(core_name).ok()?),
-                )? + 3;
-                let ptr = addr + 0x4 + game.read::<i32>(addr).ok()?;
-                Some(game.read::<Address64>(ptr).ok()?.into())
+                const SIG: Signature<8> = Signature::new("48 8B 05 ?? ?? ?? ?? C3");
+                SIG.scan_process_range(game, (base_scan, 0x100))
+                    .map(|addr| addr + 3)
+                    .and_then(|addr| {
+                        game.read::<Address64>(game.read::<Address64>(addr).ok()?)
+                            .ok()
+                    })
+                    .map(|addr| addr.into())
             } else {
-                const SIG: Signature<8> = Signature::new("A1 ?? ?? ?? ?? 23 CB 8B");
-                let ptr = SIG.scan_process_range(
-                    game,
-                    (core_address, game.get_module_size(core_name).ok()?),
-                )? + 1;
-                let ptr = game.read::<Address32>(ptr).ok()?;
-                Some(game.read::<Address32>(ptr).ok()?.into())
+                const SIG: Signature<3> = Signature::new("74 ?? A1");
+                SIG.scan_process_range(game, (base_scan, 0x100))
+                    .map(|addr| addr + 3)
+                    .and_then(|addr| {
+                        game.read::<Address32>(game.read::<Address32>(addr).ok()?)
+                            .ok()
+                    })
+                    .map(|addr| addr.into())
             }
         } else if core_name == SUPPORTED_CORES[3] {
             // PCSX ReARMed
             if is_64_bit {
-                const SIG: Signature<9> = Signature::new("48 8B 35 ?? ?? ?? ?? 81 E2");
-                let addr = SIG.scan_process_range(
-                    game,
-                    (core_address, game.get_module_size(core_name).ok()?),
-                )? + 3;
-                let ptr = addr + 0x4 + game.read::<i32>(addr).ok()?;
-                let ptr = game.read::<Address64>(ptr).ok()?;
-                Some(game.read::<Address64>(ptr).ok()?.into())
+                const SIG: Signature<10> = Signature::new("48 8B 05 ?? ?? ?? ?? 48 8B 00");
+                SIG.scan_process_range(game, (base_scan, 0x100))
+                    .map(|addr| addr + 4)
+                    .and_then(|addr| {
+                        game.read::<Address64>(
+                            game.read::<Address64>(addr + 0x4 + game.read::<i32>(addr).ok()?)
+                                .ok()?,
+                        )
+                        .ok()
+                    })
+                    .map(|addr| addr.into())
             } else {
-                const SIG: Signature<9> = Signature::new("FF FF 1F 00 89 ?? ?? ?? A1");
-                let ptr = SIG.scan_process_range(
-                    game,
-                    (core_address, game.get_module_size(core_name).ok()?),
-                )? + 9;
-                let ptr = game.read::<Address32>(ptr).ok()?;
-                Some(game.read::<Address32>(ptr).ok()?.into())
+                const SIG: Signature<8> = Signature::new("0F 44 05 ?? ?? ?? ?? C3");
+                SIG.scan_process_range(game, (base_scan, 0x100))
+                    .map(|addr| addr + 3)
+                    .and_then(|addr| {
+                        game.read::<Address32>(game.read::<Address32>(addr).ok()?)
+                            .ok()
+                    })
+                    .map(|addr| addr.into())
             }
         } else {
             None

--- a/src/emulator/ps1/retroarch.rs
+++ b/src/emulator/ps1/retroarch.rs
@@ -66,7 +66,7 @@ impl State {
                 SIG.scan_process_range(game, (base_scan, 0x100))
                     .map(|addr| addr + 3)
                     .and_then(|addr| {
-                        game.read::<Address64>(game.read::<Address64>(addr).ok()?)
+                        game.read::<Address64>(addr + 0x4 + game.read::<i32>(addr).ok()?)
                             .ok()
                     })
                     .map(|addr| addr.into())
@@ -85,7 +85,7 @@ impl State {
             if is_64_bit {
                 const SIG: Signature<10> = Signature::new("48 8B 05 ?? ?? ?? ?? 48 8B 00");
                 SIG.scan_process_range(game, (base_scan, 0x100))
-                    .map(|addr| addr + 4)
+                    .map(|addr| addr + 3)
                     .and_then(|addr| {
                         game.read::<Address64>(
                             game.read::<Address64>(addr + 0x4 + game.read::<i32>(addr).ok()?)

--- a/src/emulator/ps1/xebra.rs
+++ b/src/emulator/ps1/xebra.rs
@@ -12,11 +12,12 @@ impl State {
             .filter(|(_, state)| matches!(state, super::State::Xebra(_)))
             .find_map(|(name, _)| game.get_module_range(name).ok())?;
 
-        let ptr = SIG.scan_process_range(game, main_module_range)? + 1;
-        let addr = ptr + 0x4 + game.read::<i32>(ptr).ok()?;
-        let addr = game.read::<Address32>(addr + 0x16A).ok()?;
-        let addr = game.read::<Address32>(addr).ok()?;
-        Some(addr.into())
+        SIG.scan_process_range(game, main_module_range)
+            .map(|addr| addr + 1)
+            .and_then(|addr| Some(addr + 0x4 + game.read::<i32>(addr).ok()?))
+            .and_then(|addr| game.read::<Address32>(addr + 0x16A).ok())
+            .and_then(|addr| game.read::<Address32>(addr).ok())
+            .map(|addr| addr.into())
     }
 
     pub const fn keep_alive(&self) -> bool {


### PR DESCRIPTION
This fixes some PS1 sigscans, especially for retroarch and PCSX_rearmed, re-enabling support for those emulators