### PR TITLE
Unreal: Support retrieving arbitrary FName strings

### DIFF
--- a/src/game_engine/unreal/mod.rs
+++ b/src/game_engine/unreal/mod.rs
@@ -343,12 +343,10 @@ impl UProperty {
 pub struct FNameKey {
     name_offset: u16,
     chunk_offset: u16,
-    
 }
 
 impl FNameKey {
     /// Returns `true` if the key's values are 0
-    /// TODO: make sure (0, 0) is in fact an invalid FName
     pub fn is_null(&self) -> bool {
         self.chunk_offset == 0 && self.name_offset == 0
     }

--- a/src/game_engine/unreal/mod.rs
+++ b/src/game_engine/unreal/mod.rs
@@ -341,8 +341,9 @@ impl UProperty {
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct FNameKey {
-    chunk_offset: u16,
     name_offset: u16,
+    chunk_offset: u16,
+    
 }
 
 impl FNameKey {


### PR DESCRIPTION
Introduces `get_fname()` in `unreal::Module`, which allows users to retrieve arbitrary FName strings.  Additionally, the `FNameKey` type is introduced to support this functionality via a single memory read.  Existing `get_fname()` functions are converted to use this new functionality.

While getting the THPS series autosplitter ready for 3+4, I decided to refactor the 1+2 splitter to use the Unreal functionality of asr.  The biggest issue that I ran into was the lack of functionality for retrieving arbitrary FName strings, which I use to track goal progress.  Here's an example of its usage: https://github.com/PARTYMANX/thps-autosplitter/blob/unreal_update/src/thps12.rs#L136