### PR TITLE
Unreal: Expose UObject creation and address

### DIFF
--- a/src/game_engine/unreal/mod.rs
+++ b/src/game_engine/unreal/mod.rs
@@ -343,12 +343,10 @@ impl UProperty {
 pub struct FNameKey {
     name_offset: u16,
     chunk_offset: u16,
-    
 }
 
 impl FNameKey {
     /// Returns `true` if the key's values are 0
-    /// TODO: make sure (0, 0) is in fact an invalid FName
     pub fn is_null(&self) -> bool {
         self.chunk_offset == 0 && self.name_offset == 0
     }

--- a/src/game_engine/unreal/mod.rs
+++ b/src/game_engine/unreal/mod.rs
@@ -180,6 +180,18 @@ pub struct UObject {
 }
 
 impl UObject {
+    /// Create an arbitrary `UObject` from an address 
+    pub fn new(address: Address) -> Self {
+        Self {
+            object: address,
+        }
+    }
+
+    /// Returns the address of the current `UObject`
+    pub fn get_address(&self) -> Address {
+        self.object
+    }
+
     /// Reads the `FName` of the current `UObject`
     pub fn get_fname<const N: usize>(
         &self,

--- a/src/game_engine/unreal/mod.rs
+++ b/src/game_engine/unreal/mod.rs
@@ -341,8 +341,9 @@ impl UProperty {
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub struct FNameKey {
-    chunk_offset: u16,
     name_offset: u16,
+    chunk_offset: u16,
+    
 }
 
 impl FNameKey {


### PR DESCRIPTION
(This is built off of #110, as I needed both sets of functionality for my own testing, sorry for any confusion!)

Adds `new` and `get_address` functions to the `UObject` struct.

I refactored the THPS 1+2 and 3+4 splitters to use `UObject` fields wherever possible to make them a bit more generic (in case another game or significant updates come out), which required the `UObject` struct to be able to be created for arbitrary addresses.  I have an example of its usage here: https://github.com/PARTYMANX/thps-autosplitter/blob/unreal-stage2/src/alcatraz_utils/mod.rs#L199