### PR TITLE
Add process name for mGBA on Mac, which works out of the box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.idea

--- a/src/emulator/gba/mod.rs
+++ b/src/emulator/gba/mod.rs
@@ -224,7 +224,7 @@ pub enum State {
     Mednafen(mednafen::State),
 }
 
-static PROCESS_NAMES: [(&str, State); 7] = [
+static PROCESS_NAMES: [(&str, State); 8] = [
     (
         "visualboyadvance-m.exe",
         State::VisualBoyAdvance(vba::State::new()),
@@ -234,6 +234,7 @@ static PROCESS_NAMES: [(&str, State); 7] = [
         State::VisualBoyAdvance(vba::State::new()),
     ),
     ("mGBA.exe", State::Mgba(mgba::State)),
+    ("mGBA", State::Mgba(mgba::State)),
     ("NO$GBA.EXE", State::NoCashGba(nocashgba::State::new())),
     ("retroarch.exe", State::Retroarch(retroarch::State::new())),
     ("EmuHawk.exe", State::EmuHawk(emuhawk::State::new())),


### PR DESCRIPTION
This just works with adding just the process name.

Little video demo in case you need it: https://youtu.be/svUKSBYLce4

I didn't bother with going through all the emulators