### PR TITLE
Add timer current_split_index and timer segment_splitted

### DIFF
--- a/src/runtime/sys.rs
+++ b/src/runtime/sys.rs
@@ -79,6 +79,12 @@ extern "C" {
     pub fn timer_undo_split();
     /// Resets the timer.
     pub fn timer_reset();
+    /// Accesses the index of the split the attempt is currently on. If there's
+    /// no attempt in progress, `-1` is returned instead. This returns an
+    /// index that is equal to the amount of segments when the attempt is
+    /// finished, but has not been reset. So you need to be careful when using
+    /// this value for indexing.
+    pub fn timer_current_split_index() -> i32;
     /// Sets a custom key value pair. This may be arbitrary information that the
     /// auto splitter wants to provide for visualization. The pointers need to
     /// point to valid UTF-8 encoded text with the respective given length.

--- a/src/runtime/sys.rs
+++ b/src/runtime/sys.rs
@@ -85,6 +85,8 @@ extern "C" {
     /// finished, but has not been reset. So you need to be careful when using
     /// this value for indexing.
     pub fn timer_current_split_index() -> i32;
+    /// Whether the segment at `idx` was splitted this attempt.
+    pub fn timer_segment_splitted(idx: i32) -> bool;
     /// Sets a custom key value pair. This may be arbitrary information that the
     /// auto splitter wants to provide for visualization. The pointers need to
     /// point to valid UTF-8 encoded text with the respective given length.

--- a/src/runtime/timer.rs
+++ b/src/runtime/timer.rs
@@ -121,6 +121,11 @@ pub fn current_split_index() -> i32 {
     unsafe { sys::timer_current_split_index() }
 }
 
+/// Whether the segment at `idx` was splitted this attempt.
+pub fn segment_splitted(idx: i32) -> bool {
+    unsafe { sys::timer_segment_splitted(idx) }
+}
+
 /// Sets the game time.
 #[inline]
 pub fn set_game_time(time: time::Duration) {

--- a/src/runtime/timer.rs
+++ b/src/runtime/timer.rs
@@ -112,6 +112,15 @@ pub fn state() -> TimerState {
     }
 }
 
+/// Accesses the index of the split the attempt is currently on. If there's
+/// no attempt in progress, `-1` is returned instead. This returns an
+/// index that is equal to the amount of segments when the attempt is
+/// finished, but has not been reset. So you need to be careful when using
+/// this value for indexing.
+pub fn current_split_index() -> i32 {
+    unsafe { sys::timer_current_split_index() }
+}
+
 /// Sets the game time.
 #[inline]
 pub fn set_game_time(time: time::Duration) {


### PR DESCRIPTION
Adds timer::current_split_index and timer::segment_splitted, which allow autosplitters to detect split/skip/undo events, even if they were done manually by the user.

A companion PR to https://github.com/LiveSplit/livesplit-core/pull/884, it should only be merged after that and https://github.com/LiveSplit/LiveSplit.AutoSplittingRuntime/pull/20 have been merged and put into a main LiveSplit release.