### PR TITLE
Add functions to get the process name and main module range

### DIFF
--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -161,6 +161,14 @@ impl Process {
         }
     }
 
+    /// Gets the name of the process.
+    #[cfg(feature = "alloc")]
+    #[inline]
+    pub fn get_name(&self) -> Result<alloc::string::String, Error> {
+        let path = self.get_path()?;
+        Ok(path.split("/").last().ok_or(Error {})?.into())
+    }
+
     /// Gets the address of a module in the process.
     #[inline]
     pub fn get_module_address(&self, name: &str) -> Result<Address, Error> {
@@ -245,6 +253,14 @@ impl Process {
             process: self,
             index,
         })
+    }
+
+    /// Get the address and size of the main module in the process.
+    #[cfg(feature = "alloc")]
+    #[inline]
+    pub fn get_main_module_range(&self) -> Result<(Address, u64), Error> {
+        let main_module_name = self.get_name()?;
+        self.get_module_range(&main_module_name)
     }
 
     /// Reads a value of the type specified from the process at the address

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -165,8 +165,14 @@ impl Process {
     #[cfg(feature = "alloc")]
     #[inline]
     pub fn get_name(&self) -> Result<alloc::string::String, Error> {
-        let path = self.get_path()?;
-        Ok(path.split("/").last().ok_or(Error {})?.into())
+        let mut path = self.get_path()?;
+
+        // remove everything before the / on path to avoid an allocation
+        let (before, _) = path.rsplit_once('/').ok_or(Error {})?;
+        let index = before.len() + 1;
+        path.drain(..index);
+
+        Ok(path)
     }
 
     /// Gets the address of a module in the process.


### PR DESCRIPTION
This is something I needed to access for my scene manager stuff (need to access the range of the main module without changing the API of SceneManager::attach.

I imagine it could be useful elsewhere too.

I'm inferring the name of the main module is the same as the name of the process - I think this is a safe assumption, but let me know if not.