### PR TITLE
Add some helper functions to get the scene name and path as a string

### DIFF
--- a/src/game_engine/unity/scene_manager/scene.rs
+++ b/src/game_engine/unity/scene_manager/scene.rs
@@ -1,4 +1,4 @@
-use super::SceneManager;
+use super::{SceneManager, CSTR};
 use crate::{string::ArrayCString, Address, Error, Process};
 
 /// A scene loaded in the attached game.
@@ -24,7 +24,9 @@ impl Scene {
         process.read(self.address + scene_manager.offsets.build_index)
     }
 
-    /// Returns the full path to the scene.
+    /// Returns the full asset path of the scene.
+    ///
+    /// Usually looks like "`Assets/some/path/scene.unity`".
     pub fn path<const N: usize>(
         &self,
         process: &Process,
@@ -36,5 +38,30 @@ impl Scene {
                 scene_manager.pointer_size,
             )
             .and_then(|addr| process.read(addr))
+    }
+
+    /// Returns the full path of the scene, as a [String](alloc::string::String).
+    pub fn path_as_string(
+        &self,
+        process: &Process,
+        scene_manager: &SceneManager,
+    ) -> Result<alloc::string::String, Error> {
+        let path = self.path::<CSTR>(process, scene_manager)?;
+        let str = path.validate_utf8().map_err(|_| Error {})?;
+
+        Ok(str.into())
+    }
+
+    /// Returns the name of the scene, as a [String](alloc::string::String).
+    pub fn name(
+        &self,
+        process: &Process,
+        scene_manager: &SceneManager,
+    ) -> Result<alloc::string::String, Error> {
+        // The name is also stored in memory, but it's just easier to interpret the path
+        let path = self.path_as_string(process, scene_manager)?;
+        // if for some reason the path has no /, or doesn't end in a .unity, just safely default
+        let cs = path.rsplit_once('/').unwrap_or(("", &path)).1;
+        Ok(cs.split_once('.').unwrap_or((cs, "")).0.into())
     }
 }

--- a/src/game_engine/unity/scene_manager/scene.rs
+++ b/src/game_engine/unity/scene_manager/scene.rs
@@ -41,6 +41,7 @@ impl Scene {
     }
 
     /// Returns the full path of the scene, as a [String](alloc::string::String).
+    #[cfg(feature = "alloc")]
     pub fn path_as_string(
         &self,
         process: &Process,
@@ -53,6 +54,7 @@ impl Scene {
     }
 
     /// Returns the name of the scene, as a [String](alloc::string::String).
+    #[cfg(feature = "alloc")]
     pub fn name(
         &self,
         process: &Process,

--- a/src/game_engine/unity/scene_manager/scene.rs
+++ b/src/game_engine/unity/scene_manager/scene.rs
@@ -64,6 +64,6 @@ impl Scene {
         let path = self.path_as_string(process, scene_manager)?;
         // if for some reason the path has no /, or doesn't end in a .unity, just safely default
         let cs = path.rsplit_once('/').unwrap_or(("", &path)).1;
-        Ok(cs.split_once('.').unwrap_or((cs, "")).0.into())
+        Ok(cs.rsplit_once('.').unwrap_or((cs, "")).0.into())
     }
 }


### PR DESCRIPTION
More ergonomic to get the path directly like this. There is a get_name function elsewhere in the code, but I think most people will care about the scene name directly, so let's just expose that directly.

You can also get the scene name on the scene struct, but the way to read that is a little annoying (if the scene name is short enough, it's stored in the struct, otherwise there's a pointer to the name). Easier to just read it directly.