### PR TITLE
#[link(wasm_import_module = "env")]

### DIFF
--- a/src/runtime/sys.rs
+++ b/src/runtime/sys.rs
@@ -65,6 +65,7 @@ impl SettingValueType {
     pub const STRING: Self = Self(6);
 }
 
+#[link(wasm_import_module = "env")]
 extern "C" {
     /// Gets the state that the timer currently is in.
     pub fn timer_get_state() -> TimerState;


### PR DESCRIPTION
After these changes in Rust 1.96.0:
- https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/#changes-to-webassembly-targets
- https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/#what-is-going-to-break-and-how-to-fix

Rust has stopped passing `--allow-undefined` to the linker for WASM targets, causing linker errors like:
```
error: linking with `rust-lld` failed: exit status: 1
```
with `undefined symbol: user_settings_add_title`, `undefined symbol: user_settings_add_choice`, and so on through `undefined symbol: user_settings_add_choice_option`.

Adding `#[link(wasm_import_module = "env")]` should fix those linker errors.