### PR TITLE
Add splits path getter for autosplitters

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -91,3 +91,34 @@ pub fn get_arch() -> Result<arrayvec::ArrayString<16>, Error> {
     }
     Ok(buf)
 }
+
+/// Queries the WASI path of the currently loaded splits file (`.lss`).
+///
+/// Returns [`None`] if the host has no file (unsaved run, debugger, etc.).
+/// The path is usable with [`std::fs`] under WASI (`/mnt/...`). It may change
+/// after Save As; call this when you need the current path rather than
+/// caching it at startup unless you only care about the file that was loaded.
+///
+/// Requires the `alloc` feature.
+#[cfg(feature = "alloc")]
+#[inline]
+pub fn get_splits_path() -> Option<alloc::string::String> {
+    // SAFETY: The first call uses a null buffer and zero length to learn the
+    // required size. If that fails with length 0, the host has no file. Otherwise
+    // we allocate a buffer of that length and call again. On success the buffer
+    // is filled with valid UTF-8 that is not nul-terminated.
+    unsafe {
+        let mut len = 0;
+        let success = sys::runtime_get_splits_path(core::ptr::null_mut(), &mut len);
+        if len == 0 && !success {
+            return None;
+        }
+        let mut buf = alloc::vec::Vec::with_capacity(len);
+        let success = sys::runtime_get_splits_path(buf.as_mut_ptr(), &mut len);
+        if !success {
+            return None;
+        }
+        buf.set_len(len);
+        Some(alloc::string::String::from_utf8_unchecked(buf))
+    }
+}

--- a/src/runtime/sys.rs
+++ b/src/runtime/sys.rs
@@ -220,6 +220,16 @@ extern "C" {
     /// guaranteed to be valid UTF-8 and is not nul-terminated.
     /// Example values: `x86`, `x86_64`, `arm`, `aarch64`
     pub fn runtime_get_arch(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
+    /// Stores the file system path of the currently loaded splits file in the
+    /// buffer given. Returns `false` if the buffer is too small or the host has
+    /// no file. After this call, no matter whether it was successful or not, the
+    /// `buf_len_ptr` will be set to the required buffer size. If `false` is
+    /// returned and `buf_len_ptr` is 0, the host has no file. The path is
+    /// guaranteed to be valid UTF-8 and is not nul-terminated. It is a WASI
+    /// path (e.g. `/mnt/c/Users/.../file.lss` on Windows), suitable for
+    /// `std::fs`.
+    #[cfg(feature = "alloc")]
+    pub fn runtime_get_splits_path(buf_ptr: *mut u8, buf_len_ptr: *mut usize) -> bool;
 
     /// Adds a new boolean setting that the user can modify. This will return
     /// either the specified default value or the value that the user has set.


### PR DESCRIPTION
Adds helper support for the current splits file's WASI filesystem path getter to be added by https://github.com/LiveSplit/livesplit-core/pull/950.